### PR TITLE
Abstract the metadata from the Raz

### DIFF
--- a/eval/src/eval_iraz.rs
+++ b/eval/src/eval_iraz.rs
@@ -1,5 +1,5 @@
-use std::fmt::{self,Debug};
-use std::cmp::{min,max};
+//use std::fmt::{self,Debug};
+use std::cmp;
 use std::rc::Rc;
 use rand::{Rng,StdRng,Rand};
 use time::Duration;
@@ -14,7 +14,7 @@ use interface::{Adapt};
 /// Test harness for the incremental Raz
 ///
 /// Coorinates elements, insertion location, gen'ed levels
-#[derive(Clone)]
+#[derive(Clone,Debug)]
 pub struct EvalIRaz<E:Adapt,G:Rng> {
 	// Option for cleaner code, None means uninitialized
 	raztree: Option<IRazTree<E>>,
@@ -24,14 +24,14 @@ pub struct EvalIRaz<E:Adapt,G:Rng> {
 	unitsize: usize,
 	namesize: usize,
 }
-impl<E:Adapt,G:Rng> Debug for EvalIRaz<E,G> {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-		let tree = self.raztree.clone();
-		let size = self.raztree.clone().unwrap().len();
-		let content = tree.unwrap().into_iter().collect::<Vec<_>>();
-		write!(f,"EvalIRaz {{ size:{}, data:{:?} }}",size,content)
-	}
-}
+// impl<E:Adapt,G:Rng> Debug for EvalIRaz<E,G> {
+// 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+// 		let tree = self.raztree.clone();
+// 		let size = self.raztree.clone().unwrap().meta().0;
+// 		let content = tree.unwrap().into_iter().collect::<Vec<_>>();
+// 		write!(f,"EvalIRaz {{ size:{}, data:{:?} }}",size,content)
+// 	}
+// }
 
 impl<E:Adapt,G:Rng> EvalIRaz<E,G> {
 	pub fn new(us: usize, ns: usize, coord:G) -> Self {
@@ -158,7 +158,7 @@ impl<E:Adapt+Rand,G:Rng>
 EditInsert for EvalIRaz<E,G> {
 	fn insert(mut self, batch_size: usize, rng: &mut StdRng) -> (Duration,Self) {
 		let tree = self.raztree.take().unwrap_or_else(||panic!("raz uninitialized"));
-		let loc = self.coord.gen::<usize>() % tree.len();
+		let loc = self.coord.gen::<usize>() % tree.meta().0;
 		let mut focus = None;
 		let focus_time = Duration::span(||{
 			focus = tree.focus(loc);
@@ -200,7 +200,7 @@ impl<E:Adapt+Rand,G:Rng>
 EditAppend for EvalIRaz<E,G> {
 	fn append(mut self, batch_size: usize, rng: &mut StdRng) -> (Duration,Self) {
 		let tree = self.raztree.take().unwrap_or_else(||panic!("raz uninitialized"));
-		let len = tree.len();
+		let len = tree.meta().0;
 		let mut focus = None;
 		let focus_time = Duration::span(||{
 			focus = tree.focus(len);
@@ -237,102 +237,102 @@ EditAppend for EvalIRaz<E,G> {
 	}
 }
 
-/// Appends to a `RazTree` by focusing to the end, pushing
-/// data, levels, and names, then unfocusing
-// uses (saved) Params::{namesize,unitsize}
-// TODO: Buggy
-impl<E:Adapt+Rand,G:Rng>
-EditExtend for EvalIRaz<E,G> {
-	fn extend(mut self, batch_size: usize, rng: &mut StdRng) -> (Duration,Self) {
-		let tree = self.raztree.take().unwrap();
+// /// Appends to a `RazTree` by focusing to the end, pushing
+// /// data, levels, and names, then unfocusing
+// // uses (saved) Params::{namesize,unitsize}
+// // TODO: Buggy
+// impl<E:Adapt+Rand,G:Rng>
+// EditExtend for EvalIRaz<E,G> {
+// 	fn extend(mut self, batch_size: usize, rng: &mut StdRng) -> (Duration,Self) {
+// 		let tree = self.raztree.take().unwrap();
 
-		// measure stuff
-		let len = tree.len();
-		let mut newelems = batch_size;
-		// fill in the level
-		let levelless = len % self.unitsize;
-		let pre_elems = min(self.unitsize - levelless, newelems);
-		let madelevel = if levelless + pre_elems == self.unitsize {1} else {0}; 
-		newelems -= pre_elems;
-		// fill in the name
-		let nameless = len % (self.namesize*self.unitsize);
-		let pre_levels = min(
-			(self.namesize - nameless - pre_elems) / self.unitsize,
-			newelems / self.unitsize
-		);
-		let madename = if
-			nameless / self.unitsize + madelevel + pre_levels
-			== self.namesize
-			{1} else {0}
-		;
-		newelems -= pre_levels * self.unitsize;
-		// add more names etc. like above
-		let names = newelems /(self.namesize*self.unitsize);
-		let new_levels = madelevel + pre_levels + (newelems / self.unitsize);
-		let nonames = newelems - names;
-		let units = nonames / self.unitsize;
-		let nounits = nonames - units;
+// 		// measure stuff
+// 		let len = tree.meta().0;
+// 		let mut newelems = batch_size;
+// 		// fill in the level
+// 		let levelless = len % self.unitsize;
+// 		let pre_elems = cmp::min(self.unitsize - levelless, newelems);
+// 		let madelevel = if levelless + pre_elems == self.unitsize {1} else {0}; 
+// 		newelems -= pre_elems;
+// 		// fill in the name
+// 		let nameless = len % (self.namesize*self.unitsize);
+// 		let pre_levels = cmp::min(
+// 			(self.namesize - nameless - pre_elems) / self.unitsize,
+// 			newelems / self.unitsize
+// 		);
+// 		let madename = if
+// 			nameless / self.unitsize + madelevel + pre_levels
+// 			== self.namesize
+// 			{1} else {0}
+// 		;
+// 		newelems -= pre_levels * self.unitsize;
+// 		// add more names etc. like above
+// 		let names = newelems /(self.namesize*self.unitsize);
+// 		let new_levels = madelevel + pre_levels + (newelems / self.unitsize);
+// 		let nonames = newelems - names;
+// 		let units = nonames / self.unitsize;
+// 		let nounits = nonames - units;
 
-		// pregenerate data
-		let mut lev_vec = Vec::with_capacity(new_levels);
-		for _ in 0..(new_levels) {
-			lev_vec.push(gen_level(rng))
-		}
-		let mut name_vec = Vec::with_capacity(madename + names*self.namesize);
-		if madename == 1 {name_vec.push(Some(self.next_name()))}
-		for _ in 0..names {
-			for _ in 0..(self.namesize-1){
-				// no name with these levels
-				name_vec.push(None)
-			}
-			name_vec.push(Some(self.next_name()));
-		}
-		let mut data_iter = self.coord.gen_iter().take(batch_size).collect::<Vec<_>>().into_iter();
-		let mut name_iter = name_vec.into_iter();
-		let mut level_iter = lev_vec.into_iter();
+// 		// pregenerate data
+// 		let mut lev_vec = Vec::with_capacity(new_levels);
+// 		for _ in 0..(new_levels) {
+// 			lev_vec.push(gen_level(rng))
+// 		}
+// 		let mut name_vec = Vec::with_capacity(madename + names*self.namesize);
+// 		if madename == 1 {name_vec.push(Some(self.next_name()))}
+// 		for _ in 0..names {
+// 			for _ in 0..(self.namesize-1){
+// 				// no name with these levels
+// 				name_vec.push(None)
+// 			}
+// 			name_vec.push(Some(self.next_name()));
+// 		}
+// 		let mut data_iter = self.coord.gen_iter().take(batch_size).collect::<Vec<_>>().into_iter();
+// 		let mut name_iter = name_vec.into_iter();
+// 		let mut level_iter = lev_vec.into_iter();
 
-		// time the append
-		let time = Duration::span(||{
-			// finish the last level, name
-			let mut raz = tree.focus(len).expect("02");
-			for _ in 0..pre_elems {
-				raz.push_left(data_iter.next().expect("03"));
-			}
-			for _ in 0..pre_levels {
-				raz.archive_left(level_iter.next().expect("04"), None);
-				for _ in 0..self.unitsize {
-					raz.push_left(data_iter.next().expect("05"));
-				}
-			}
-			if madename == 1 {
-				raz.archive_left(level_iter.next().expect("06"), name_iter.next().expect("07"))
-			} else if madelevel == 1 {
-				raz.archive_left(level_iter.next().expect("08"), None)
-			}
-			// add new elms, levels, names, like above
-			for _ in 0..names {
-				for _ in 0..self.namesize {
-					for _ in 0..self.unitsize {
-						raz.push_left(data_iter.next().expect("09"));
-					}
-					raz.archive_left(level_iter.next().expect("10"), name_iter.next().expect("11"));
-				}
-				// name inserted above
-			}
-			for _ in 0..units {
-				for _ in 0..self.unitsize {
-					raz.push_left(data_iter.next().expect("12"));
-				}
-				raz.archive_left(level_iter.next().expect("13"), None);
-			}
-			for _ in 0..nounits {
-				raz.push_left(data_iter.next().expect("14"));
-			}
-			self.raztree = Some(raz.unfocus());
-		});
-		(time,self)
-	}
-}
+// 		// time the append
+// 		let time = Duration::span(||{
+// 			// finish the last level, name
+// 			let mut raz = tree.focus(len).expect("02");
+// 			for _ in 0..pre_elems {
+// 				raz.push_left(data_iter.next().expect("03"));
+// 			}
+// 			for _ in 0..pre_levels {
+// 				raz.archive_left(level_iter.next().expect("04"), None);
+// 				for _ in 0..self.unitsize {
+// 					raz.push_left(data_iter.next().expect("05"));
+// 				}
+// 			}
+// 			if madename == 1 {
+// 				raz.archive_left(level_iter.next().expect("06"), name_iter.next().expect("07"))
+// 			} else if madelevel == 1 {
+// 				raz.archive_left(level_iter.next().expect("08"), None)
+// 			}
+// 			// add new elms, levels, names, like above
+// 			for _ in 0..names {
+// 				for _ in 0..self.namesize {
+// 					for _ in 0..self.unitsize {
+// 						raz.push_left(data_iter.next().expect("09"));
+// 					}
+// 					raz.archive_left(level_iter.next().expect("10"), name_iter.next().expect("11"));
+// 				}
+// 				// name inserted above
+// 			}
+// 			for _ in 0..units {
+// 				for _ in 0..self.unitsize {
+// 					raz.push_left(data_iter.next().expect("12"));
+// 				}
+// 				raz.archive_left(level_iter.next().expect("13"), None);
+// 			}
+// 			for _ in 0..nounits {
+// 				raz.push_left(data_iter.next().expect("14"));
+// 			}
+// 			self.raztree = Some(raz.unfocus());
+// 		});
+// 		(time,self)
+// 	}
+// }
 
 impl<E:Adapt+Ord,G:Rng>
 CompMax for EvalIRaz<E,G> {
@@ -341,7 +341,7 @@ CompMax for EvalIRaz<E,G> {
 		let clone = self.raztree.clone().unwrap();
 		let mut max_val = None;
 		let time = Duration::span(||{
-	    	max_val = Some(clone.fold_up(Rc::new(|e:&E|e.clone()),Rc::new(|e1:E,e2:E|max(e1,e2))))
+	    	max_val = Some(clone.fold_up(Rc::new(|e:&E|e.clone()),Rc::new(|e1:E,e2:E|cmp::max(e1,e2))))
 		});
 		(time,max_val.unwrap())
 	}
@@ -379,20 +379,21 @@ CompMap<E,O,F> for EvalIRaz<E,G> where
 
 }
 
-impl<E:Adapt,O:Adapt,F,G:Rng>
-CompFold<E,O,F> for EvalIRaz<E,G> where
-	F:'static + Fn(O,&E)->O,
-{
-	type Target = O;
-	fn comp_fold(&self, accum: O, f:Rc<F>, _rng: &mut StdRng) -> (Duration,Self::Target) {
-		let clone = self.raztree.clone().unwrap();
-		let mut res = None;
-		let time = Duration::span(||{
-			res = Some(clone.fold_lr(accum,f));
-		});
-		(time, res.unwrap())
-	}
-}
+// Uses the old buggy fold
+// impl<E:Adapt,O:Adapt,F,G:Rng>
+// CompFold<E,O,F> for EvalIRaz<E,G> where
+// 	F:'static + Fn(O,&E)->O,
+// {
+// 	type Target = O;
+// 	fn comp_fold(&self, accum: O, f:Rc<F>, _rng: &mut StdRng) -> (Duration,Self::Target) {
+// 		let clone = self.raztree.clone().unwrap();
+// 		let mut res = None;
+// 		let time = Duration::span(||{
+// 			res = Some(clone.fold_lr(accum,f));
+// 		});
+// 		(time, res.unwrap())
+// 	}
+// }
 
 impl<E:Adapt,O:Adapt,F,N,G:Rng>
 CompFoldMeta<E,O,(u32,Option<Name>),F,N> for EvalIRaz<E,G> where

--- a/eval/src/test_seq.rs
+++ b/eval/src/test_seq.rs
@@ -85,8 +85,8 @@ pub struct TestMResult<I,O> {
 	in_type: PhantomData<I>,
 	out_type: PhantomData<O>,
 }
-use std::fmt::Debug;
-impl<C,E,U,I:Debug,O:Debug>
+//use std::fmt::Debug;
+impl<C,E,U,I,O>
 Testor<TestMResult<I,O>>
 for EditComputeSequence<C,E,U> where
 	C: Creator<Duration,I>,

--- a/src/inc_gauged_raz.rs
+++ b/src/inc_gauged_raz.rs
@@ -233,7 +233,7 @@ impl<E: Debug+Clone+Eq+Hash+'static, M:RazMeta<E>> RazTree<E,M> {
 						SideChoice::Here => {
 							assert!(cursor.down_left());
 							while cursor.down_right() {}
-							index = M::Index::first();
+							index = M::Index::last();
 						},
 						SideChoice::Nowhere => { return None }, 
 					}

--- a/src/inc_gauged_raz.rs
+++ b/src/inc_gauged_raz.rs
@@ -14,7 +14,7 @@ use inc_level_tree::{Tree};
 use inc_tree_cursor as tree;
 use inc_tree_cursor::TreeUpdate;
 use inc_archive_stack as stack;
-use raz_meta::{RazMeta,SideChoice,Count,FirstLast};
+use raz_meta::{RazMeta,Navigation,Count,FirstLast};
 use memo::{MemoFrom};
 
 use adapton::macros::*;
@@ -222,21 +222,21 @@ impl<E: Debug+Clone+Eq+Hash+'static, M:RazMeta<E>> RazTree<E,M> {
 				// step 1: find location with cursor
 				let mut cursor = tree::Cursor::from(tree);
 				while let TreeData::Branch(l,r) = cursor.peek().unwrap() {
-					match M::choose_side(&l,&r,&index) {
-						SideChoice::Left(i) => {
+					match M::navigate(&l,&r,&index) {
+						Navigation::Left(i) => {
 							assert!(cursor.down_left());
 							index = i;
 						},
-						SideChoice::Right(i) => {
+						Navigation::Right(i) => {
 							assert!(cursor.down_right());
 							index = i;
 						},
-						SideChoice::Here => {
+						Navigation::Here => {
 							assert!(cursor.down_left());
 							while cursor.down_right() {}
 							index = M::Index::last();
 						},
-						SideChoice::Nowhere => { return None }, 
+						Navigation::Nowhere => { return None }, 
 					}
 				}
 				// step 2: extract and copy data

--- a/src/inc_gauged_raz.rs
+++ b/src/inc_gauged_raz.rs
@@ -118,14 +118,6 @@ impl<E: Debug+Clone+Eq+Hash+'static, M:RazMeta<E>> RazTree<E,M> {
 		})
 	}
 
-	// /// left-to-right memoized fold (Old version, poor incremental performance)
-	// pub fn fold_lr<A,B>(self, init: A, bin: Rc<B>) -> A where
-	// 	A: 'static + Eq+Clone+Hash+Debug,
-	// 	B: 'static + Fn(A,&E) -> A,
-	// {
-	// 	self.into_iter().inc_fold_out(init,bin)
-	// }
-
 	/// left-to-right memoized fold with levels and names
 	pub fn fold_lr_meta<A,B,N>(self, init: A, bin: Rc<B>, meta: Rc<N>) -> A where
 		A: 'static + Eq+Clone+Hash+Debug,
@@ -507,14 +499,14 @@ Raz<E,M> {
 // impl<T: Debug+Clone+Eq+Hash+'static> Iterator for IterL<T> {
 // 	type Item = T;
 // 	fn next(&mut self) -> Option<Self::Item> {
-// 		self.0.pop_left()
+// 		unimplemented!() // don't change the data!
 // 	}
 // }
 // pub struct IterR<T: Debug+Clone+Eq+Hash+'static>(Raz<T>);
 // impl<T: Debug+Clone+Eq+Hash+'static> Iterator for IterR<T> {
 // 	type Item = T;
 // 	fn next(&mut self) -> Option<Self::Item> {
-// 		self.0.pop_right()
+// 		unimplemented!() // don't change the data!
 // 	}
 // }
 // impl<T: Debug+Clone+Eq+Hash+'static> IterR<T> {

--- a/src/inc_gauged_raz.rs
+++ b/src/inc_gauged_raz.rs
@@ -1178,12 +1178,12 @@ mod tests {
 		}
 		let t = r.unfocus();
 
-		println!("top: {:?}", t.meta());
+		//println!("top: {:?}", t.meta());
 
 		for _ in 0..10 {
 			let val = (thread_rng().gen::<usize>() % 100) * 10;
 			let tree_name = name_pair(name_of_usize(val),name_of_string(String::from("tree")));
-			println!("{:?}", tree_name);
+			//println!("{:?}", tree_name);
 			let r = t.clone().focus(tree_name).unwrap();
 			assert_eq!(Some(val), r.peek_left());
 		}

--- a/src/inc_gauged_trie_opt.rs
+++ b/src/inc_gauged_trie_opt.rs
@@ -4,7 +4,7 @@
 //! Concretely, they consist of skip-list-like structures.
 
 use std::mem;
-use std::fmt;
+//use std::fmt;
 use std::rc::Rc;
 use std::fmt::Debug;
 use std::hash::{Hash,Hasher};

--- a/src/inc_level_tree.rs
+++ b/src/inc_level_tree.rs
@@ -302,7 +302,7 @@ mod tests {
 				Tree::new(0,None,Some(6),None,None),
 			)
 		).unwrap();
-		let tree_plus1 = t.clone().map(Rc::new(|d: Option<usize>| {
+		let tree_plus1 = t.clone().map(Rc::new(|d: Option<usize>,_l,_n,_t1:Option<&_>,_t2:Option<&_>| {
 			d.map(|n|n+1)
 		}));
 		let leaf = tree_plus1.l_tree().unwrap().r_tree().unwrap().l_tree().unwrap().r_tree().unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@ pub mod inc_level_tree;
 pub mod inc_tree_cursor;
 pub mod inc_gauged_raz;
 pub mod raz_meta;
-pub mod inc_gauged_trie;
+// pub mod inc_gauged_trie;
 pub mod inc_gauged_trie_opt;
 
 /// Persistent Raz - original design, simple but works

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@ pub mod inc_archive_stack;
 pub mod inc_level_tree;
 pub mod inc_tree_cursor;
 pub mod inc_gauged_raz;
+pub mod raz_meta;
 pub mod inc_gauged_trie;
 pub mod inc_gauged_trie_opt;
 
@@ -41,14 +42,14 @@ pub mod inc_gauged_trie_opt;
 pub type PRaz<E> = persist_raz::Raz<E>;
 /// Unfocused `PRaz`
 pub type PRazTree<E> = persist_raz::RazSeq<E>;
-/// Raz - Sequence editing. Vectorized leaves, manualy defined
+/// Raz - Sequence editing. Vectorized leaves, manually defined
 pub type Raz<E> = gauged_raz::Raz<trees::NegBin,E>;
 /// Unfocused `Raz`
 pub type RazTree<E> = gauged_raz::RazTree<trees::NegBin,E>;
 /// Incremental Raz - Experimental for use with Adapton
-pub type IRaz<E> = inc_gauged_raz::Raz<E>;
+pub type IRaz<E> = inc_gauged_raz::Raz<E,raz_meta::Count>;
 /// Unfocused `IRaz`
-pub type IRazTree<E> = inc_gauged_raz::RazTree<E>;
+pub type IRazTree<E> = inc_gauged_raz::RazTree<E,raz_meta::Count>;
 /// Stack-based sequence editing
 pub type Zipper<E> = zip::Stacks<E>;
 /// Functional programming's common list, persistent

--- a/src/raz_meta.rs
+++ b/src/raz_meta.rs
@@ -7,7 +7,7 @@ use std::hash::Hash;
 use adapton::engine::Name;
 
 pub trait RazMeta<E>: Sized+Debug+Clone+Eq+Hash {
-	type Index;
+	type Index: FirstLast;
 
 	/// create meta data for an empty branch
 	fn from_none() -> Self;
@@ -18,7 +18,7 @@ pub trait RazMeta<E>: Sized+Debug+Clone+Eq+Hash {
 	/// The names passed into here are USED in the tree that it
 	/// rebuilds the meta data for, and should not be used again to
 	/// name arts
-	fn from_meta(l: &Self, r: &Self, l: u32, n: Option<Name>) -> Self;
+	fn from_meta(l: &Self, r: &Self, lev: u32, n: Option<Name>) -> Self;
 	/// choose a branch and create an adjusted index for that branch
 	fn choose_side(l: &Self, r: &Self, index: &Self::Index) -> SideChoice<Self::Index>;
 	/// splits a vec into slices based on the index
@@ -30,9 +30,35 @@ pub enum SideChoice<T> {
 	Left(T), Right(T), Here, Nowhere
 }
 
+pub trait FirstLast {
+	fn first() -> Self;
+	fn last() -> Self;
+}
+
+impl<E> RazMeta<E> for () {
+	type Index = ();
+
+	fn from_none() -> Self { () }
+	fn from_vec(_vec: &Vec<E>) -> Self { () }
+	fn from_meta(_l: &Self, _r: &Self, _lev: u32, _n: Option<Name>) -> Self { () }
+	fn choose_side(_l: &Self, _r: &Self, _index: &Self::Index) -> SideChoice<Self::Index> {
+		SideChoice::Nowhere
+	}
+	/// # Panics
+	/// always panics
+	fn split_vec<'a>(_vec: &'a Vec<E>, _index: &Self::Index) -> (&'a [E],&'a [E]) {
+		panic!("no indexing available")
+	}
+}
+
+impl FirstLast for () {
+	fn first() -> Self {()}
+	fn last() -> Self {()}
+}
+
 /// Meta data for element count and positioning from the left
 #[derive(Clone,Eq,PartialEq,Hash,Debug)]
-pub struct Count(usize);
+pub struct Count(pub usize);
 
 impl<E> RazMeta<E> for Count {
 	type Index = usize;
@@ -58,8 +84,17 @@ impl<E> RazMeta<E> for Count {
 	/// # Panics
 	/// Panics if the index is too high
 	fn split_vec<'a>(vec: &'a Vec<E>, index: &Self::Index) -> (&'a [E],&'a [E]) {
-		vec.split_at(*index)
+		if *index == usize::max_value() {
+			vec.split_at(vec.len())
+		} else {
+			vec.split_at(*index)	
+		}
 	}	
+}
+
+impl FirstLast for usize {
+	fn first() -> Self { usize::max_value() }
+	fn last() -> Self { 0 }
 }
 
 // TODO: HashMap

--- a/src/raz_meta.rs
+++ b/src/raz_meta.rs
@@ -1,0 +1,65 @@
+//! Available meta data for the inc_gauged_raz
+//! 
+//! This meta data will be used when focusing into the Raz
+
+use std::fmt::Debug;
+use std::hash::Hash;
+use adapton::engine::Name;
+
+pub trait RazMeta<E>: Sized+Debug+Clone+Eq+Hash {
+	type Index;
+
+	/// create meta data for an empty branch
+	fn from_none() -> Self;
+	/// create meta data from a leaf vec
+	fn from_vec(vec: &Vec<E>) -> Self;
+	/// create meta data from the pair of meta data in branches
+	///
+	/// The names passed into here are USED in the tree that it
+	/// rebuilds the meta data for, and should not be used again to
+	/// name arts
+	fn from_meta(l: &Self, r: &Self, l: u32, n: Option<Name>) -> Self;
+	/// choose a branch and create an adjusted index for that branch
+	fn choose_side(l: &Self, r: &Self, index: &Self::Index) -> SideChoice<Self::Index>;
+	/// splits a vec into slices based on the index
+	fn split_vec<'a>(vec: &'a Vec<E>, index: &Self::Index) -> (&'a [E],&'a [E]);
+}
+
+/// A location and possibly an index for that location
+pub enum SideChoice<T> {
+	Left(T), Right(T), Here, Nowhere
+}
+
+/// Meta data for element count and positioning from the left
+#[derive(Clone,Eq,PartialEq,Hash,Debug)]
+pub struct Count(usize);
+
+impl<E> RazMeta<E> for Count {
+	type Index = usize;
+
+	fn from_none() -> Self { Count(0) }
+	fn from_vec(vec: &Vec<E>) -> Self {
+		Count(vec.len())
+	}
+	fn from_meta(&Count(l): &Self, &Count(r): &Self, _l: u32, _n: Option<Name>) -> Self {
+		Count(l+r)
+	}
+	fn choose_side(
+		&Count(l): &Self,
+		&Count(r): &Self,
+		index: &Self::Index
+	) -> SideChoice<Self::Index> {
+		let i = *index;
+		if i > l + r { SideChoice::Nowhere }
+		else if i > l { SideChoice::Right(i - l) }
+		else if i == l { SideChoice::Here }
+		else { SideChoice::Left(i) }
+	}
+	/// # Panics
+	/// Panics if the index is too high
+	fn split_vec<'a>(vec: &'a Vec<E>, index: &Self::Index) -> (&'a [E],&'a [E]) {
+		vec.split_at(*index)
+	}	
+}
+
+// TODO: HashMap

--- a/src/raz_meta.rs
+++ b/src/raz_meta.rs
@@ -163,8 +163,16 @@ impl FirstLast for NameIndex {
 impl<E> RazMeta<E> for Names {
 	type Index = NameIndex;
 
-	fn from_none() -> Self { Names(HashMap::new()) }
-	fn from_vec(_vec: &Vec<E>) -> Self { Names(HashMap::new()) }
+	fn from_none(_lev: u32, n: Option<Name>) -> Self {
+		let mut h = HashMap::new();
+		match n {None=>{},Some(nm)=>{ h.insert(nm,()); }}
+		Names(h)
+	}
+	fn from_vec(_vec: &Vec<E>, _lev: u32, n: Option<Name>) -> Self {
+		let mut h = HashMap::new();
+		match n {None=>{},Some(nm)=>{ h.insert(nm,()); }}
+		Names(h)
+	}
 	fn from_meta(l: &Self, r: &Self, _lev: u32, n: Option<Name>) -> Self {
 		let mut h = HashMap::new();
 		for k in l.0.keys() { h.insert(k.clone(),()); }

--- a/src/raz_meta.rs
+++ b/src/raz_meta.rs
@@ -6,13 +6,26 @@ use std::fmt::Debug;
 use std::hash::Hash;
 use adapton::engine::Name;
 
+/// trait for creating and searching for meta data in the
+/// branches of the raz. There are two pieces of meta data
+/// in each node, one created from its left branch and one
+/// created from its right branch. The level and name from
+/// the current node are also available.
 pub trait RazMeta<E>: Sized+Debug+Clone+Eq+Hash {
 	type Index: FirstLast;
 
 	/// create meta data for an empty branch
-	fn from_none() -> Self;
+	///
+	/// The names passed into here are USED in the tree that it
+	/// rebuilds the meta data for, and should not be used again to
+	/// name arts
+	fn from_none(lev: u32, n: Option<Name>) -> Self;
 	/// create meta data from a leaf vec
-	fn from_vec(vec: &Vec<E>) -> Self;
+	///
+	/// The names passed into here are USED in the tree that it
+	/// rebuilds the meta data for, and should not be used again to
+	/// name arts
+	fn from_vec(vec: &Vec<E>, lev: u32, n: Option<Name>) -> Self;
 	/// create meta data from the pair of meta data in branches
 	///
 	/// The names passed into here are USED in the tree that it
@@ -38,8 +51,8 @@ pub trait FirstLast {
 impl<E> RazMeta<E> for () {
 	type Index = OnlyEnds;
 
-	fn from_none() -> Self { () }
-	fn from_vec(_vec: &Vec<E>) -> Self { () }
+	fn from_none(_lev: u32, _n: Option<Name>) -> Self { () }
+	fn from_vec(_vec: &Vec<E>, _lev: u32, _n: Option<Name>) -> Self { () }
 	fn from_meta(_l: &Self, _r: &Self, _lev: u32, _n: Option<Name>) -> Self { () }
 	fn choose_side(_l: &Self, _r: &Self, index: &Self::Index) -> SideChoice<Self::Index> {
 		match *index {
@@ -77,8 +90,8 @@ pub struct Count(pub usize);
 impl<E> RazMeta<E> for Count {
 	type Index = usize;
 
-	fn from_none() -> Self { Count(0) }
-	fn from_vec(vec: &Vec<E>) -> Self {
+	fn from_none(_lev: u32, _n: Option<Name>) -> Self { Count(0) }
+	fn from_vec(vec: &Vec<E>, _lev: u32, _n: Option<Name>) -> Self {
 		Count(vec.len())
 	}
 	fn from_meta(&Count(l): &Self, &Count(r): &Self, _l: u32, _n: Option<Name>) -> Self {


### PR DESCRIPTION
I'm making this a pull request because it's a significant change.

Instead of item counts stored in the Raz branches, there is now arbitrary metadata, from a trait defined in `raz_meta.rs`. I wrote a "Count" metadata that restores the old functionality.

I updated the incremental map function to take all the node data as input. Meta data needs to be updated manually during a mapping, but the outer API takes care of this.

All our previous tests/evaluations still work with similar results.

I commented out some iterators that need updating. Previously, they were only used in formatting debugging text. I'll fix them up on demand.