### PR TITLE
Hash trie; for creating finite maps from sequences

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,3 @@ travis-ci = { repository = "https://github.com/cuplv/iodyn.rust" }
 [dependencies]
 rand = "0.3"
 adapton = "0.3"
-
-#[dependencies.adapton]
-#path = "/Users/hammer/repo/adapton.rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,6 @@ travis-ci = { repository = "https://github.com/cuplv/iodyn.rust" }
 [dependencies]
 rand = "0.3"
 adapton = "0.3"
+
+#[dependencies.adapton]
+#path = "/Users/hammer/repo/adapton.rust"

--- a/eval/Cargo.toml
+++ b/eval/Cargo.toml
@@ -3,6 +3,9 @@ name = "eval"
 version = "0.1.0"
 authors = ["kyleheadley <kyle.headley@colorado.edu>"]
 
+#[dependencies.adapton]
+#path = "/Users/hammer/repo/adapton.rust"
+
 [dependencies]
 iodyn = { path = "../" }
 adapton = "0.3"
@@ -10,6 +13,7 @@ adapton-lab = "0.1"
 time = "0.1"
 rand = "0.3"
 streaming-stats = "0.1"
+
 
 [dev-dependencies]
 clap = "2"

--- a/eval/examples/unique_elms.rs
+++ b/eval/examples/unique_elms.rs
@@ -114,7 +114,7 @@ fn main2() {
     },
     edit: BatchInsert(edits),
     comp: TreeFoldG::new(
-      |v:&Vec<usize>|{ () },
+      |v:&Vec<GenSetElm>|{ () },
       move|t1,lev,nm,t2|{ () },
     ),
     changes: changes,
@@ -170,7 +170,7 @@ fn main2() {
   // for visual debugging
   if do_trace {reflect::dcg_reflect_begin()}
 
-  let result_trie: TestResult<EvalIRaz<GenSetElm,StdRng>> = panic!(""); //test_trie.test(&mut rng);
+  let result_trie: TestResult<EvalIRaz<GenSetElm,StdRng>> = test_trie.test(&mut rng);
 
   if do_trace {
     let traces = reflect::dcg_reflect_end();

--- a/eval/examples/unique_elms.rs
+++ b/eval/examples/unique_elms.rs
@@ -137,7 +137,7 @@ fn main2() {
       |v:&Vec<GenSetElm>|{ Trie2::<_,()>::from_key_vec_ref(v) },
       move|t1,_lev,nm,t2|{ 
           let nm2 = nm.clone();
-          ns(nm.unwrap().clone(), || Trie2::join(nm2.unwrap(),t1,t2) )
+          ns(nm.unwrap().clone(), || Trie2::join(Some(nm2.unwrap()),t1,t2) )
       },
     ),
     changes: changes,

--- a/eval/examples/unique_elms.rs
+++ b/eval/examples/unique_elms.rs
@@ -179,7 +179,7 @@ fn main2() {
   // for visual debugging
   if do_trace {reflect::dcg_reflect_begin()}
 
-  let result_trie1: TestResult<EvalIRaz<GenSetElm,StdRng>,_> = test_trie1.test(&mut rng);
+  //let result_trie1: TestResult<EvalIRaz<GenSetElm,StdRng>,_> = test_trie1.test(&mut rng);
 
   if do_trace {
     let traces = reflect::dcg_reflect_end();
@@ -244,12 +244,12 @@ fn main2() {
 
   // post-process results
   let comp_hash = result_hash.computes.iter().map(|d|d[0].num_nanoseconds().unwrap()).collect::<Vec<_>>();
-  let comp_trie1 = result_trie1.computes.iter().map(|d|d.num_nanoseconds().unwrap()).collect::<Vec<_>>();
+  //let comp_trie1 = result_trie1.computes.iter().map(|d|d.num_nanoseconds().unwrap()).collect::<Vec<_>>();
   let comp_trie2 = result_trie2.computes.iter().map(|d|d.num_nanoseconds().unwrap()).collect::<Vec<_>>();
   let comp_ivl = inc_veclist.computes.iter().map(|d|d[0].num_nanoseconds().unwrap()).collect::<Vec<_>>();
 
   let edit_hash = result_hash.edits.iter().map(|d|d.num_nanoseconds().unwrap()).collect::<Vec<_>>();
-  let edit_trie1 = result_trie1.edits.iter().map(|d|d.num_nanoseconds().unwrap()).collect::<Vec<_>>();
+  //let edit_trie1 = result_trie1.edits.iter().map(|d|d.num_nanoseconds().unwrap()).collect::<Vec<_>>();
   let edit_trie2 = result_trie2.edits.iter().map(|d|d.num_nanoseconds().unwrap()).collect::<Vec<_>>();
   let edit_ivl = inc_veclist.edits.iter().map(|d|d.num_nanoseconds().unwrap()).collect::<Vec<_>>();
   
@@ -257,7 +257,7 @@ fn main2() {
   println!("----------------------------------------------------------------------------------");
   println!("Computation time (ms): (initial run, first incremental run); Note:do_trace={:?}", do_trace);
   println!("hashmap:  ({:8.3}, {:8.3})", comp_hash[0] as f32 / 1000000.0, comp_hash[1] as f32 / 1000000.0);
-  println!("trie1:     ({:8.3}, {:8.3})", comp_trie1[0] as f32 / 1000000.0, comp_trie1[1] as f32 / 1000000.0);
+  //println!("trie1:     ({:8.3}, {:8.3})", comp_trie1[0] as f32 / 1000000.0, comp_trie1[1] as f32 / 1000000.0);
   println!("trie2:     ({:8.3}, {:8.3})", comp_trie2[0] as f32 / 1000000.0, comp_trie2[1] as f32 / 1000000.0);
   println!("vec_list: ({:8.3}, {:8.3})", comp_ivl[0]  as f32 / 1000000.0, comp_ivl[1]  as f32 / 1000000.0);
 
@@ -289,14 +289,14 @@ fn main2() {
     c += comp_hash[i] as f64 / 1_000_000.0;
     writeln!(dat,"{}\t{}\t{}\t{}",i,e,c,e+c).unwrap();    
   }
-  writeln!(dat,"").unwrap();
-  writeln!(dat,"").unwrap();
-  e = 0.0; c = 0.0;
-  for i in 0..changes {
-    e += edit_trie1[i] as f64 / 1_000_000.0;
-    c += comp_trie1[i] as f64 / 1_000_000.0;
-    writeln!(dat,"{}\t{}\t{}\t{}",i,e,c,e+c).unwrap();    
-  }
+  // writeln!(dat,"").unwrap();
+  // writeln!(dat,"").unwrap();
+  // e = 0.0; c = 0.0;
+  // for i in 0..changes {
+  //   e += edit_trie1[i] as f64 / 1_000_000.0;
+  //   c += comp_trie1[i] as f64 / 1_000_000.0;
+  //   writeln!(dat,"{}\t{}\t{}\t{}",i,e,c,e+c).unwrap();    
+  // }
   writeln!(dat,"").unwrap();
   writeln!(dat,"").unwrap();
   e = 0.0; c = 0.0;
@@ -349,7 +349,7 @@ fn main2() {
   //writeln!(plotscript,"'{}' i 1 u 1:4 t '{}' with linespoints,\\",filename.to_owned()+".dat","Inc Skiplist total").unwrap();
 
   //writeln!(plotscript,"'{}' i 1 u 1:3:4 t '{}' with filledcu fs solid 0.1,\\",filename.to_owned()+".dat", "Inc Trie edit").unwrap();
-  writeln!(plotscript,"'{}' i 1 u 1:3 t '{}' with linespoints,\\",filename.to_owned()+".dat","Inc Trie1").unwrap();
+  //writeln!(plotscript,"'{}' i 1 u 1:3 t '{}' with linespoints,\\",filename.to_owned()+".dat","Inc Trie1").unwrap();
   writeln!(plotscript,"'{}' i 2 u 1:3 t '{}' with linespoints,\\",filename.to_owned()+".dat","Inc Trie2").unwrap();
   //writeln!(plotscript,"'{}' i 1 u 1:4 t '{}' with linespoints,\\",filename.to_owned()+".dat","Inc Trie total").unwrap();
 

--- a/eval/examples/unique_elms.rs
+++ b/eval/examples/unique_elms.rs
@@ -350,11 +350,11 @@ fn main2() {
 
   //writeln!(plotscript,"'{}' i 1 u 1:3:4 t '{}' with filledcu fs solid 0.1,\\",filename.to_owned()+".dat", "Inc Trie edit").unwrap();
   //writeln!(plotscript,"'{}' i 1 u 1:3 t '{}' with linespoints,\\",filename.to_owned()+".dat","Inc Trie1").unwrap();
-  writeln!(plotscript,"'{}' i 2 u 1:3 t '{}' with linespoints,\\",filename.to_owned()+".dat","Inc Trie2").unwrap();
+  writeln!(plotscript,"'{}' i 1 u 1:3 t '{}' with linespoints,\\",filename.to_owned()+".dat","Inc Trie2").unwrap();
   //writeln!(plotscript,"'{}' i 1 u 1:4 t '{}' with linespoints,\\",filename.to_owned()+".dat","Inc Trie total").unwrap();
 
   //writeln!(plotscript,"'{}' i 2 u 1:3:4 t '{}' with filledcu fs solid 0.1,\\",filename.to_owned()+".dat", "Inc List edit").unwrap();
-  writeln!(plotscript,"'{}' i 3 u 1:3 t '{}' with linespoints,\\",filename.to_owned()+".dat","Inc List").unwrap();
+  writeln!(plotscript,"'{}' i 2 u 1:3 t '{}' with linespoints,\\",filename.to_owned()+".dat","Inc List").unwrap();
   //writeln!(plotscript,"'{}' i 2 u 1:4 t '{}' with linespoints,\\",filename.to_owned()+".dat","Inc List total").unwrap();
 
   ::std::process::Command::new("gnuplot").arg(filename.to_owned()+".plotscript").output().unwrap();

--- a/eval/examples/unique_elms.rs
+++ b/eval/examples/unique_elms.rs
@@ -114,8 +114,11 @@ fn main2() {
     },
     edit: BatchInsert(edits),
     comp: TreeFoldG::new(
-      |v:&Vec<GenSetElm>|{ () },
-      move|t1,lev,nm,t2|{ () },
+      |v:&Vec<GenSetElm>|{ Trie::<_,()>::from_key_vec(v) },
+      move|t1,_lev,nm,t2|{ 
+          let nm2 = nm.clone();
+          ns(nm.unwrap().clone(),||Trie::join(t1, t2, nm2.unwrap())) 
+      },
     ),
     changes: changes,
   };
@@ -217,7 +220,7 @@ fn main2() {
   println!("----------------------------------------------------------------------------------");
   println!("Computation time (ms): (initial run, first incremental run); Note:do_trace={:?}", do_trace);
   println!("hashmap:  ({:8.3}, {:8.3})", comp_hash[0] as f32 / 1000000.0, comp_hash[1] as f32 / 1000000.0);
-  println!("trie:     ({:8.3}, {:8.3})", comp_trie[0] as f32 / 1000000.0, comp_skiplist[1] as f32 / 1000000.0);
+  println!("trie:     ({:8.3}, {:8.3})", comp_trie[0] as f32 / 1000000.0, comp_trie[1] as f32 / 1000000.0);
   println!("skiplist: ({:8.3}, {:8.3})", comp_skiplist[0] as f32 / 1000000.0, comp_skiplist[1] as f32 / 1000000.0);
   println!("vec_list: ({:8.3}, {:8.3})", comp_ivl[0]  as f32 / 1000000.0, comp_ivl[1]  as f32 / 1000000.0);
 

--- a/eval/examples/unique_elms.rs
+++ b/eval/examples/unique_elms.rs
@@ -127,7 +127,8 @@ fn main2() {
   let mut testskiplist = EditComputeSequence{
     init: IncrementalInit {
       size: start_size,
-      datagauge: datagauge,
+      //datagauge: datagauge,
+      datagauge: 1,
       namegauge: namegauge,
       coord: coord.clone(),
     },
@@ -220,8 +221,8 @@ fn main2() {
   println!("----------------------------------------------------------------------------------");
   println!("Computation time (ms): (initial run, first incremental run); Note:do_trace={:?}", do_trace);
   println!("hashmap:  ({:8.3}, {:8.3})", comp_hash[0] as f32 / 1000000.0, comp_hash[1] as f32 / 1000000.0);
-  println!("trie:     ({:8.3}, {:8.3})", comp_trie[0] as f32 / 1000000.0, comp_trie[1] as f32 / 1000000.0);
   println!("skiplist: ({:8.3}, {:8.3})", comp_skiplist[0] as f32 / 1000000.0, comp_skiplist[1] as f32 / 1000000.0);
+  println!("trie:     ({:8.3}, {:8.3})", comp_trie[0] as f32 / 1000000.0, comp_trie[1] as f32 / 1000000.0);
   println!("vec_list: ({:8.3}, {:8.3})", comp_ivl[0]  as f32 / 1000000.0, comp_ivl[1]  as f32 / 1000000.0);
 
   ///////
@@ -302,21 +303,22 @@ fn main2() {
   writeln!(plotscript,"set mxtics 5           # set the spacing for the mxtics").unwrap();
   writeln!(plotscript,"set grid               # enable the grid").unwrap();
   writeln!(plotscript,"plot \\").unwrap();
-  writeln!(plotscript,"'{}' i 0 u 1:3:4 t '{}' with filledcu fs solid 0.1,\\",filename.to_owned()+".dat", "Non-Inc HashMap edit").unwrap();
+  
+  //writeln!(plotscript,"'{}' i 0 u 1:3:4 t '{}' with filledcu fs solid 0.1,\\",filename.to_owned()+".dat", "Non-Inc HashMap edit").unwrap();
   writeln!(plotscript,"'{}' i 0 u 1:3 t '{}' with linespoints,\\",filename.to_owned()+".dat","Non-Inc HashMap compute").unwrap();
-  writeln!(plotscript,"'{}' i 0 u 1:4 t '{}' with linespoints,\\",filename.to_owned()+".dat","Non-Inc HashMap total").unwrap();
+  //writeln!(plotscript,"'{}' i 0 u 1:4 t '{}' with linespoints,\\",filename.to_owned()+".dat","Non-Inc HashMap total").unwrap();
 
-  writeln!(plotscript,"'{}' i 1 u 1:3:4 t '{}' with filledcu fs solid 0.1,\\",filename.to_owned()+".dat", "Inc Skiplist edit").unwrap();
+  //writeln!(plotscript,"'{}' i 1 u 1:3:4 t '{}' with filledcu fs solid 0.1,\\",filename.to_owned()+".dat", "Inc Skiplist edit").unwrap();
   writeln!(plotscript,"'{}' i 1 u 1:3 t '{}' with linespoints,\\",filename.to_owned()+".dat","Inc Skiplist compute").unwrap();
-  writeln!(plotscript,"'{}' i 1 u 1:4 t '{}' with linespoints,\\",filename.to_owned()+".dat","Inc Skiplist total").unwrap();
+  //writeln!(plotscript,"'{}' i 1 u 1:4 t '{}' with linespoints,\\",filename.to_owned()+".dat","Inc Skiplist total").unwrap();
 
-  writeln!(plotscript,"'{}' i 1 u 1:3:4 t '{}' with filledcu fs solid 0.1,\\",filename.to_owned()+".dat", "Inc Trie edit").unwrap();
-  writeln!(plotscript,"'{}' i 1 u 1:3 t '{}' with linespoints,\\",filename.to_owned()+".dat","Inc Trie compute").unwrap();
-  writeln!(plotscript,"'{}' i 1 u 1:4 t '{}' with linespoints,\\",filename.to_owned()+".dat","Inc Trie total").unwrap();
+  //writeln!(plotscript,"'{}' i 1 u 1:3:4 t '{}' with filledcu fs solid 0.1,\\",filename.to_owned()+".dat", "Inc Trie edit").unwrap();
+  writeln!(plotscript,"'{}' i 2 u 1:3 t '{}' with linespoints,\\",filename.to_owned()+".dat","Inc Trie compute").unwrap();
+  //writeln!(plotscript,"'{}' i 1 u 1:4 t '{}' with linespoints,\\",filename.to_owned()+".dat","Inc Trie total").unwrap();
 
-  writeln!(plotscript,"'{}' i 2 u 1:3:4 t '{}' with filledcu fs solid 0.1,\\",filename.to_owned()+".dat", "Inc List edit").unwrap();
-  writeln!(plotscript,"'{}' i 2 u 1:3 t '{}' with linespoints,\\",filename.to_owned()+".dat","Inc List compute").unwrap();
-  writeln!(plotscript,"'{}' i 2 u 1:4 t '{}' with linespoints,\\",filename.to_owned()+".dat","Inc List total").unwrap();
+  //writeln!(plotscript,"'{}' i 2 u 1:3:4 t '{}' with filledcu fs solid 0.1,\\",filename.to_owned()+".dat", "Inc List edit").unwrap();
+  writeln!(plotscript,"'{}' i 3 u 1:3 t '{}' with linespoints,\\",filename.to_owned()+".dat","Inc List compute").unwrap();
+  //writeln!(plotscript,"'{}' i 2 u 1:4 t '{}' with linespoints,\\",filename.to_owned()+".dat","Inc List total").unwrap();
 
   ::std::process::Command::new("gnuplot").arg(filename.to_owned()+".plotscript").output().unwrap();
 

--- a/eval/examples/unique_elms.rs
+++ b/eval/examples/unique_elms.rs
@@ -28,7 +28,7 @@ use adapton_lab::labviz::*;
 #[allow(unused)] use eval::accum_lists::*;
 
 //use iodyn::inc_gauged_trie::{FinMap,Trie};
-use iodyn::skiplist::{FinMap,Skiplist};
+//use iodyn::skiplist::{FinMap,Skiplist};
 use iodyn::trie2::{Trie};
 use eval::test_seq::{TestResult,TestMResult,EditComputeSequence};
 use adapton::engine::manage::*;
@@ -114,7 +114,7 @@ fn main2() {
     },
     edit: BatchInsert(edits),
     comp: TreeFoldG::new(
-      |v:&Vec<GenSetElm>|{ Trie::<_,()>::from_key_vec(v) },
+      |v:&Vec<GenSetElm>|{ Trie::<_,()>::from_key_vec_ref(v) },
       move|t1,_lev,nm,t2|{ 
           let nm2 = nm.clone();
           ns(nm.unwrap().clone(),||Trie::join(t1, t2, nm2.unwrap())) 

--- a/eval/examples/unique_elms.rs
+++ b/eval/examples/unique_elms.rs
@@ -29,7 +29,7 @@ use adapton_lab::labviz::*;
 
 //use iodyn::inc_gauged_trie::{FinMap,Trie};
 use iodyn::skiplist::{FinMap,Skiplist};
-use iodyn::trie::{Trie};
+use iodyn::trie2::{Trie};
 use eval::test_seq::{TestResult,TestMResult,EditComputeSequence};
 use adapton::engine::manage::*;
 use adapton::engine::*;
@@ -305,19 +305,19 @@ fn main2() {
   writeln!(plotscript,"plot \\").unwrap();
   
   //writeln!(plotscript,"'{}' i 0 u 1:3:4 t '{}' with filledcu fs solid 0.1,\\",filename.to_owned()+".dat", "Non-Inc HashMap edit").unwrap();
-  writeln!(plotscript,"'{}' i 0 u 1:3 t '{}' with linespoints,\\",filename.to_owned()+".dat","Non-Inc HashMap compute").unwrap();
+  writeln!(plotscript,"'{}' i 0 u 1:3 t '{}' with linespoints,\\",filename.to_owned()+".dat","(Native) HashMap").unwrap();
   //writeln!(plotscript,"'{}' i 0 u 1:4 t '{}' with linespoints,\\",filename.to_owned()+".dat","Non-Inc HashMap total").unwrap();
 
   //writeln!(plotscript,"'{}' i 1 u 1:3:4 t '{}' with filledcu fs solid 0.1,\\",filename.to_owned()+".dat", "Inc Skiplist edit").unwrap();
-  writeln!(plotscript,"'{}' i 1 u 1:3 t '{}' with linespoints,\\",filename.to_owned()+".dat","Inc Skiplist compute").unwrap();
+  writeln!(plotscript,"'{}' i 1 u 1:3 t '{}' with linespoints,\\",filename.to_owned()+".dat","Inc Skiplist").unwrap();
   //writeln!(plotscript,"'{}' i 1 u 1:4 t '{}' with linespoints,\\",filename.to_owned()+".dat","Inc Skiplist total").unwrap();
 
   //writeln!(plotscript,"'{}' i 1 u 1:3:4 t '{}' with filledcu fs solid 0.1,\\",filename.to_owned()+".dat", "Inc Trie edit").unwrap();
-  writeln!(plotscript,"'{}' i 2 u 1:3 t '{}' with linespoints,\\",filename.to_owned()+".dat","Inc Trie compute").unwrap();
+  writeln!(plotscript,"'{}' i 2 u 1:3 t '{}' with linespoints,\\",filename.to_owned()+".dat","Inc Trie").unwrap();
   //writeln!(plotscript,"'{}' i 1 u 1:4 t '{}' with linespoints,\\",filename.to_owned()+".dat","Inc Trie total").unwrap();
 
   //writeln!(plotscript,"'{}' i 2 u 1:3:4 t '{}' with filledcu fs solid 0.1,\\",filename.to_owned()+".dat", "Inc List edit").unwrap();
-  writeln!(plotscript,"'{}' i 3 u 1:3 t '{}' with linespoints,\\",filename.to_owned()+".dat","Inc List compute").unwrap();
+  writeln!(plotscript,"'{}' i 3 u 1:3 t '{}' with linespoints,\\",filename.to_owned()+".dat","Inc List").unwrap();
   //writeln!(plotscript,"'{}' i 2 u 1:4 t '{}' with linespoints,\\",filename.to_owned()+".dat","Inc List total").unwrap();
 
   ::std::process::Command::new("gnuplot").arg(filename.to_owned()+".plotscript").output().unwrap();

--- a/eval/src/types.rs
+++ b/eval/src/types.rs
@@ -40,7 +40,7 @@ impl Add for Gen10k{
 #[derive(Clone,Copy,Debug,PartialEq,Eq,PartialOrd,Ord)]
 pub struct Elm(pub usize);
 
-const HASH_LOOP_COUNT: usize = 100;
+const HASH_LOOP_COUNT: usize = 1;
 impl Hash for Elm {
     fn hash<H: Hasher>(&self, state: &mut H) {
         for _ in 0..HASH_LOOP_COUNT {

--- a/src/kvlog.rs
+++ b/src/kvlog.rs
@@ -5,13 +5,12 @@ use std::hash::{Hash, Hasher};
 use adapton::engine::*;
 use trie2;
 
+#[derive(Clone,PartialEq,Eq,Debug,Hash)]
 struct Hashval ( u64 );
 
-pub enum Log<K,V> {
-    Empty,
-    Chunks(Chunk<K, V>)
-}
+pub type Log<K,V> = Option<Chunk<K, V>>;
 
+#[derive(Clone,PartialEq,Eq,Debug,Hash)]
 enum Trie<K,V> {
     Bin(Box<Trie<K,V>>, Box<Trie<K,V>>),
     Mapping(HashvalMask, Mapping<K,V>)
@@ -19,37 +18,107 @@ enum Trie<K,V> {
 
 type HashvalMask = (Hashval, usize);
 
+#[derive(Clone,PartialEq,Eq,Debug,Hash)]
 enum Mapping<K,V> {
-    Empty, 
-    Here, 
+    Empty,
+    Here,
     There(Art<Chunk<K, V>>),
 }
 
+#[derive(Clone,PartialEq,Eq,Debug,Hash)]
 pub struct Chunk<K,V> {
     here: Vec<(K, V)>,
-    there: Trie<K, V>,
-    prev: Art<Chunk<K, V>>
+    there: Option<Trie<K, V>>,
+    prev: Option<Art<Chunk<K,V>>>,
 }
 
 pub fn emp
     <K:'static+Hash+PartialEq+Eq+Clone+Debug,
      V:'static+Hash+PartialEq+Eq+Clone+Debug>
-    () -> Log<K,V> { 
-        Log::Empty
+    () -> Log<K,V> { None }
+
+fn compute_trie
+    <K:'static+Hash+PartialEq+Eq+Clone+Debug,
+     V:'static+Hash+PartialEq+Eq+Clone+Debug>
+    (log:Log<K,V>) -> Log<K,V> {
+        match log {
+            None => None,
+            Some(chunk) => {
+                // compute 'there' trie for the key-value pairs that
+                // are 'here' in the chunk.
+                unimplemented!()
+            }
+        }
+    }
+
+pub fn archive
+    <K:'static+Hash+PartialEq+Eq+Clone+Debug,
+     V:'static+Hash+PartialEq+Eq+Clone+Debug>
+    (an:Option<Name>, log:Log<K,V>) -> Log<K,V> {
+        match an {
+            None => log,
+            Some(n) => {
+                let log = compute_trie(log);
+                Some(Chunk{
+                    here: Vec::new(),
+                    there: None,
+                    prev: match log {
+                        None => None,
+                        Some(c) => Some(cell(n, c))
+                    }
+                })
+            }
+        }
     }
 
 pub fn put
     <K:'static+Hash+PartialEq+Eq+Clone+Debug,
      V:'static+Hash+PartialEq+Eq+Clone+Debug>
     (an:Option<Name>, log:Log<K,V>, k:K, v:V) -> Log<K,V> {
+        let mut log = archive(an, log);
+        match log {
+            None =>
+                return Some(Chunk{
+                    here: vec![(k,v)],
+                    there: None,
+                    prev: None,
+                }),
+            Some(ref mut c) => {
+                c.here.push((k,v));
+            }
+        };
+        return log
+    }
+
+pub fn chunk_find
+    <K:'static+Hash+PartialEq+Eq+Clone+Debug,
+     V:'static+Hash+PartialEq+Eq+Clone+Debug>
+    (c:&Chunk<K,V>, k:&K) -> Option<V> {
+        for &(ref ck, ref cv) in c.here.iter() /* FIXME: reverse! */ {
+            if k == ck { return Some(cv.clone()); }
+        };
+        // Do a look-up in the Trie 'there', to find the next
+        // Chunk to search with a linear scan (as above).
         unimplemented!()
     }
+
 
 pub fn get
     <K:'static+Hash+PartialEq+Eq+Clone+Debug,
      V:'static+Hash+PartialEq+Eq+Clone+Debug>
-    (an:Option<Name>, log:Log<K,V>, k:K) -> (Log<K,V>, Option<V>) {
-        unimplemented!()
+    (an:Option<Name>, mut log:Log<K,V>, k:&K) -> (Log<K,V>, Option<V>) {
+        match log {
+            None => (None, None),
+            Some(c) => {
+                let ret = chunk_find(&c, &k);
+                // if value is found, record it 'here', otherwise, record nothing in log.
+                match ret {
+                    None =>        { log = Some(c) },
+                    Some(ref v) => { log = put(an, Some(c), k.clone(), v.clone()) }
+                };
+                (log, ret)
+            }
+        }
     }
 
 pub fn into_trie

--- a/src/kvlog.rs
+++ b/src/kvlog.rs
@@ -1,4 +1,204 @@
-use std::fmt;
+// author: matthew.hammer@colorado.edu
+/*! 
+**Key-value log**, a sequence of key-value accesses _and updates_.
+
+# Key value log
+
+A key-value log records a (totally-ordered) sequential history of
+associations between keys and values.  For efficiency (to tune
+overhead), we store the log in a chunked representation, permitting us
+to amortize each Adapton-level operation over _many_ key-value log
+operations, which form chunks.
+
+## Interface overview
+
+Abstract type `Log` represents a chunky key-value log:
+
+- function `emp` produces the empty `Log`  
+- function `get` accesses the latest value for a given key  
+- function `put` updates the value for the given key  
+- function `archive` controls the representation's chunking, including the role of
+   persistence and Adapton-level amortization.
+
+## Implementation discussion
+
+We give a discussion of implementation details.
+
+### Chunky representation
+
+The chunky log representation amortizes Adapton operations over many
+`put`/`get` operations.
+
+- function `put` does not require any Adapton operations (it only
+affects the current chunk), and 
+
+- function `get` uses Adapton operations in some cases, but not all:
+
+  - `get` does not require Adapton observations for keys bound in the
+    _current chunk_.
+
+  - To resolve keys from _earlier chunks_, `get` observes `Art`s holding
+    earlier chunks by using the chunks' _kv tables_, explained in detail
+    below.  The expected number of such operations is related to the
+    [expected fanout](#expected-fanout).
+
+  - Transparently, `get` caches observations in the current chunk, to
+    permit efficient `get` operations for any frequently-accessed keys.
+
+- Function `archive` does not affect the key-value association.
+Instead, it advances the chunked representation of the log by
+completing the current chunk, and starting a new, empty chunk.  Behind
+the scenes, it "completes" the chunk by computing the chunk's kv
+table, and it stores the chunk in a single Adapton `Art` cell.
+
+### Chunky list, chunky sequences
+
+Collectively, the log's chunks form a linked list (via a `prev` field
+in each chunk), permitting us to transform the log to and from other
+sequence-based structures, including a RAZ, which we can edit
+effectively in a uniformly random way.
+
+### Chunky trie, via "kv tables"
+
+In contrast to a standard list/sequence representation, the log also
+forms a ("chunky") trie structure.  In particular, each completed
+chunk holds its key-value pairs in an immutable, persistent "kv
+table" that references earlier chunks with similar key hashes.
+
+Conceptually, these kv tables represent a trie of the keys' hashes,
+providing sub-linear time access to the log's most recent chunk to
+update a given key of interest. In this sense, the log uses the
+representation of a _chunky_ hash trie, or a trie indexed by the
+hashes of keys, but allocated and addressed in a "chunky" way.
+
+Concretely, the kv table of each chunk consists of a reference
+counted hash table whose expected size the same as the _expected chunk
+size_ (the expected number of key-value pairs between each _name_),
+multiplied by the _expected address length_.
+
+## Expected address length
+
+As the number of distinct keys varies, the size of the conceptual trie
+varies.  In expectation, with more keys, we require more hash bits to
+distinguish any two of them.  For workloads with large numbers of
+distinct keys (where one chunk is insufficient to hold all of the
+keys' current values), we use "jump bits" to locate keys from earlier
+chunks. In particular, for each jump bit, for each key, the kv table
+of a chunk stores a "jump" (a pointer) to an earlier chunk.
+
+The **expected address length** is the _expected number of bits
+required to distinguish any two keys_.
+
+Equivalently, the expected address length of a kv log is the expected
+length of each non-singleton path in the conceptual trie.  A bit
+string addresses a _singleton path_ when it forms the prefix of
+exactly one key.  A (non-empty) non-singleton path consists of a bit
+string that forms the prefix of two or more distinct keys.
+
+### Bit string addresses for keys
+
+We divide the hash of each key (the "key bits") into three parts:  
+
+- the "chunk bits" (least significant), e.g., 10 bits,
+- the "jump bits" (next significant), e.g., the next 0--20 bits and  
+- the extra bits (least significant) that we do not use.
+
+The number of "key bits" should suffice to make each distinct key have
+a good chance of having a distinct hash.  In practice, we choose 64
+bits; we detect and tolerate collisions, so this choice seems
+sufficient.
+
+Ideally, the number of "chunk bits" plus the number of "jump bits"
+should be close to the [expected address
+length](#expected-address-length) of the kv log.
+
+**Examples**  
+
+- For 4096 distinct keys, we expect the address length to be 12 bits,
+since 2^12 = 4096; if we set the chunk size to 1k, the number of chunk
+and jump bits is 10 and 2, respectively.
+
+- For 1M distinct keys and 1k chunks, we may want 10 jump bits, since
+1M = 2^20 = 2^(10+10).
+
+Generally, the number of "chunk bits" should be related to the
+expected size of each chunk and when the number of keys is much larger
+than this number, the "jump bits" should suffice to make lookups cheap
+(requiring more bits, generally).  However, these jump bits come at a
+cost when building and incrementally maintaining the kv log: Behind
+the scenes, we store a "jump" (a pointer) for each each jump bit, for
+each (unique) chunk key.
+
+### Tuning costs and bit lengths
+
+Ideally, the number of "jump bits" should augment the "chunk bits" to
+uniquely identify each key (i.e., they should total the number of
+expected address bits).  For instance, for 2^20 = 1M distinct keys, we
+may choose to have 10 "chunk bits" and 10 "jump bits", for 20 bits
+total.  In this case, we choose the "jump bits" such that the number
+of extra bits is zero.
+
+In practice, computing and storing jump pointers has an upfront cost.
+To tune this, we chould set the number of "jump bits" to be fewer
+than this ideal choice, and the "chunk bits" plus "jump bits" together
+may not assign distinct bits to distinct key bit strings.  
+
+Varying this balance presents a trade off: the imprecision of having
+fewer bits for locating keys makes _building_ the log's kv tables
+cheaper, but each _key lookup_ later on becomes (potentially) less
+precise and more expensive, in expectation.  
+
+In the limit, the number of "jump bits" is zero, and only the "chunk
+bits" are used to distinguish keys, where the number of keys could be
+`O(n)`, where `n` is much larger than the number keys of a single
+chunk.  In this limit case, jump sequences that search for a key
+contain _many_ distinct keys (`O(n)` of them, in expectation), and
+consequently, key lookups take `O(n)` worst-case time.
+
+### Fanout metrics
+
+In addition to the time and space costs mentioned above, we wish to
+analytically (_combinatorially_) characterize the cost of Adapton's DCG
+representation, which caches the construction of the kv log. To do so,
+we introduce the following definitions:
+
+- The **expected pointer fanout** of a chunk is the expected number
+  of distinct **chunks** that each chunk _directly references_ in its kv
+  table.
+
+- The **expected dependency fanout** of a chunk is the expected
+  number of distinct **chunks** that each chunk _directly observes_
+  while 
+  - performing `get` operations on earlier chunks and 
+  - performing the `archive` operation, which computes the chunk's kv table, and its jump pointers.
+  - (recall that `put` operations do not observe earlier chunks)
+
+Conjecture: The expected dependency fanout is less than or equal to
+the expected pointer fanout. (Proof: ?)
+
+Question: How are these two fanout metrics related combinatorially?
+(How are they related empirically?)
+
+Question: For chunk size C and distinct keys K, and a uniform
+distribution of operations over keys, what are the expected fan outs
+of the log's chunks?
+
+In particular, how is it related to the expected path length?
+
+!*/
+
+// ### Example
+
+// TODO: Check calculations in example below (might be imprecise/wrong):
+
+// For 2048 distinct keys, and chunk sizes of 1k, we expect the path
+// length to be 1 bit, since 10 bits (1024 slots) only require 1
+// additional bit to distinguish 2048 items. For 1M distinct keys and 1k
+// chunks, the expected path length is 10 bits (10 chunk bits + 10 path
+// bits = 20 bits total, which suffices for 1M items, in expectation).
+
+//use std::fmt;
+use std::rc::Rc;
 use std::fmt::Debug;
 use std::hash::{Hash, Hasher};
 use std::collections::hash_map::HashMap;
@@ -6,30 +206,91 @@ use std::collections::hash_map::HashMap;
 use adapton::engine::*;
 use trie2;
 
-#[derive(Clone,PartialEq,Eq,Debug,Hash)]
-struct Hashval ( u64 );
+const CHUNK_BITS : u32 = 0x4ff;
 
 #[derive(Clone,PartialEq,Eq,Debug,Hash)]
 pub struct Log<K,V> ( Option<Chunk<K, V>> );
 
-type HashvalMask = (Hashval, usize);
-
+// log chunk
 #[derive(Clone,PartialEq,Eq,Debug)]
-pub struct Chunk<K,V> {
-    here: Vec<(K, V)>,
-    there: JumpTable<K, V>,
+struct Chunk<K, V> {
+    here: Here<K, V>,
     prev: Option<Art<Chunk<K, V>>>,
+    name: Option<Name>,
+}
+// The key-value pairs "here" consist of either a vector of tuples, or
+// a pre-computed "kv table".
+#[derive(Clone,PartialEq,Eq,Debug)]
+enum Here<K,V> {
+    Vec(Vec<(K, KeyBits, V)>),
+    Table(Rc<KvTable<K, V>>)
 }
 
-type JumpTable<K,V> = HashMap<usize,Option<Art<Chunk<K,V>>>> ;
+// some bits of the key's full hash value, used to create a "kv table"
+// (partially) mapping this hash prefix to a `Kv`.
+#[derive(Clone,PartialEq,Eq,Debug,Hash)]
+struct ChunkBits ( u32 );
 
+// the key's full hash value, used to create a "kv table"
+// (partially) mapping this hash prefix to a `Kv`.
+#[derive(Clone,PartialEq,Eq,Debug,Hash)]
+struct KeyBits ( u64 );
+
+// map "chunk bits" to `Kv`s.
+//
+// For chunks of size 1k, choose the number of "chunk bits" to be ~10,
+// since exp(2, 10) = 1024.  As the log grows, there can never be more
+// than 1024 entries in the kv table of any chunk (by the pigeon
+// hole principle), and these entries will always reflect the "most
+// recent" jump paths, since the kv tables accumulate the jumps of
+// all prior chunks, in order.
+type KvTable<K,V> = HashMap<ChunkBits, Vec<Kv<K, V>>> ;
+
+// a "kv" is a hash, a key-value pair (whose key has the given hash),
+// and a collection of one or more "jump" pointers to previous chunks
+// that have keys with related hash strings.
+#[derive(Clone,PartialEq,Eq,Debug,Hash)]
+struct Kv<K, V> {
+    // bits consists of all of the hash bits of the key, including the
+    // "here" bits and "path" bits. if this full hash matches during a
+    // key-value lookup, the lookup key's value is in the current
+    // chunk, and no jump to another chunk is necessary. otherwise, if
+    // the "chunk bits" match but the full bits do not, consult the
+    // `path` field at the offset of first "path bit" mismatch.
+    bits: KeyBits,
+    // for each "path bit" in the Kv, we give an optional log chunk.
+    // This chunk represents where to lookup next when the lookup bit
+    // does not match a path bit. if all jump bits match, but two keys
+    // are distinct, then use `prev` to find earlier occurrences of
+    // the same bit pattern.
+    path: Vec<Option<Art<Chunk<K, V>>>>,
+    // Key
+    key: K,
+    // Value
+    val: V,
+    // the previous chunk that contains a key with _the exact same_
+    // chunk bits and jump bits. this field is needed when two distinct
+    // keys have the same chunk+jump bits; it permits us to traverse
+    // the chunks that contain both keys.
+    prev: Option<Art<Chunk<K,V>>>,
+}
+
+// Adapton engine requires the Hash trait for data in Arts, but it's
+// not used for nominal Arts, which should be the norm here.  This
+// trait is only used for an Art that is named structurally (via the
+// hash of its content).
 impl<K:Hash,V:Hash> Hash for Chunk<K,V> {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.here.hash(state);
-        self.prev.hash(state);        
-        for (ref bits, ref opart) in self.there.iter() {
-            bits.hash(state);
-            opart.hash(state);
+        self.name.hash(state);
+        self.prev.hash(state);
+        match self.here {
+            Here::Vec(ref kvs) => kvs.hash(state),
+            Here::Table(ref kvt) => {
+                for (ref bits, ref kvs) in kvt.iter() {
+                    bits.hash(state);
+                    kvs.hash(state);
+                }
+            }
         }
     }
 }
@@ -39,15 +300,182 @@ impl <K:'static+Hash+PartialEq+Eq+Clone+Debug,
 
     pub fn emp() -> Log<K,V> { Log(None) }
 
-    pub fn put(&mut self, key: K, val: V) {
-        unimplemented!()
+    fn build_path_rec
+        (bits: KeyBits,
+         chunk_art: Option<&Art<Chunk<K,V>>>, chunk: &Chunk<K,V>,
+         depth: usize, path: &mut Vec<Option<Art<Chunk<K,V>>>>)
+         -> Option<Art<Chunk<K,V>>>
+    {
+        match chunk.here {
+            Here::Vec(ref kvs) => {
+                for &(ref k, ref kbits, ref v) in kvs.iter() {
+                    if bits.0 == kbits.0 {
+                        assert_eq!(chunk_art, None);
+                        return None
+                    }
+                    else { continue }
+                };
+                // not found "here", so do a lookup in previous chunk
+                match chunk.prev {
+                    None => None,
+                    Some(ref prev) => {
+                        Self::build_path_rec(bits, Some(prev), &force(prev), 
+                                            depth /* ?? */, path /* ?? */)
+                    },
+                }
+            }
+            Here::Table(ref kvt) => {
+                let here_bits = ChunkBits((bits.0 & (CHUNK_BITS as u64)) as u32);
+                match kvt.get(&here_bits) {
+                    None => { 
+                        // the key does not exist
+                        return None 
+                    }
+                    Some(kvs) => {
+                        // first, look for an exact KeyBits match among the Kvs
+                        for kv in kvs.iter() {
+                            // compare kv.bits with bits. How many of them match?
+                            // assert invariant: at least depth (+1?) bits match?
+                            if bits == kv.bits {
+                                return chunk_art.map(|x|x.clone())
+                            }
+                        };
+                        // no exact match for all KeyBits here.  So,
+                        // we need to "jump" to another chunk.
+                        let mut next_chunk_art : Option<&Art<Chunk<K,V>>> = None;
+                        // to determine the next chunk, look for
+                        // longest KeyBits match among the Kvs we
+                        // have in `kvs`, and the chunk with the
+                        // longest matching KeyBits prefix (as given
+                        // by the path vector of the longest jump).
+                        for kv in kvs.iter() {
+                            // TODO look for longest match among the Kvs
+                        };
+                        // find the next chunk by looking in the
+                        // longest match among the jumps.
+                        match next_chunk_art {
+                            None => None,
+                            Some(chunk_art) => {
+                                return Self::build_path_rec
+                                    (bits, Some(chunk_art), &force(chunk_art),
+                                     depth + 1 /* len TODO/??? */ , path)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn archive(mut self, on:Option<Name>) -> Self {
+        match self.0 {
+            None => Log(Some(Chunk{
+                here:Here::Vec(vec![]),
+                prev:None,
+                name:on,
+            })),
+            Some(mut chunk) => {
+                let jt = HashMap::new();
+                match chunk.here {
+                    Here::Table(kvt) => {
+                        // not possible, since an invariant is that
+                        // the head of every log is a chunk with Vec
+                        // representation.
+                        unreachable!()
+                    },
+                    Here::Vec(kvs) => {
+                        // initial kv table consists of most recent key bindings from _this chunk_:
+                        for (k, kbits, v) in kvs /* TODO: reverse order; bigger indices first */ {
+                            // let k_bits = hash(k);
+                            // if k not already in jt {
+                            //   let here_bits = here_bits(k_bits);
+                            //   let mut path = Vec::new();
+                            //   let prev = build_path_rec(k_bits, prev, &prev_art, here_bits_depth, &mut path);
+                            //   jt.update(here_bits, ||vec::new(), |v| v.push(Kv{bits:k_bits, path:path, prev:prev}));
+                            // }
+                            unimplemented!()
+                        }; 
+                        // next, temporarily borrow chunk to follow
+                        // prev pointer; update any "holes" in the kv
+                        // table with kvs from the previous kv table.
+                        { 
+                            let x: &Option<Art<Chunk<K,V>>> = &chunk.prev ;
+                            let prev_jt : Rc<KvTable<K,V>> =
+                                match force(
+                                    // TODO-minor: better syntax for
+                                    // this unwrap-ref-option pattern?
+                                    match *x {Some(ref x) => x, 
+                                              None => unreachable!()} ).here {
+                                    Here::Table(ref kvt) => kvt.clone(),
+                                    Here::Vec(_) => unreachable!(),
+                                }
+                            ;
+                            for (bits, kvs) in prev_jt.iter() {
+                                // if not jt.mem(bits) { jt.add(bits, kvs.clone()) }
+                                // else { /* do nothing */ }
+                                drop((bits, kvs));
+                                unimplemented!()
+                            }
+                        };
+                        // save the kv table we just computed,
+                        // replacing the vector representation of the
+                        // current chunk. 
+                        chunk.here = Here::Table(Rc::new(jt));
+                        // The new/empty chunk consists of an empty
+                        // vector; current chunk becomes the previous
+                        // chunk of this new, empty head chunk.
+                        Log(Some(Chunk{
+                            here:Here::Vec(vec![]),
+                            prev:Some(cell!([on.clone()]? chunk)),
+                            name:on,
+                        }))
+                    }
+                }
+            }
+        }
     }
 
     pub fn get(&mut self, key: K) -> Option<V> {
         unimplemented!()
     }
 
+    pub fn put(&mut self, key: K, val: V) {
+        unimplemented!()
+    }
+
     pub fn into_trie(self) -> trie2::Trie<K,V> {
+        unimplemented!()
+    }
+}
+
+/// Key-value log with linear operations (no references)
+///
+/// `LinLog` Demonstrates another API variation, where the log is
+/// _moved_ by its operations, as a _"linear resource"_. The mutable
+/// ref interface for `Log` suffices to implement this interface.
+struct LinLog<K,V> (Log<K,V>);
+impl <K:'static+Hash+PartialEq+Eq+Clone+Debug,
+      V:'static+Hash+PartialEq+Eq+Clone+Debug> LinLog<K,V> {
+
+    pub fn emp() -> LinLog<K,V> {
+        LinLog(Log(None))
+    }
+
+    pub fn archive(mut self, on:Option<Name>) -> LinLog<K,V> {
+        LinLog(self.0.archive(on))
+    }
+
+    pub fn put(mut self, key: K, val: V) -> LinLog<K,V> {
+        self.0.put(key, val);
+        self
+    }
+
+    pub fn get(mut self, key: K) -> (Option<V>, LinLog<K,V>) {
+        let vo = self.0.get(key);
+        (vo, self)
+    }
+
+    pub fn into_trie(mut self) -> trie2::Trie<K,V> {
         unimplemented!()
     }
 }

--- a/src/kvlog.rs
+++ b/src/kvlog.rs
@@ -1,0 +1,60 @@
+use std::fmt;
+use std::fmt::Debug;
+use std::hash::{Hash, Hasher};
+
+use adapton::engine::*;
+use trie2;
+
+struct Hashval ( u64 );
+
+pub enum Log<K,V> {
+    Empty,
+    Chunks(Chunk<K, V>)
+}
+
+enum Trie<K,V> {
+    Bin(Box<Trie<K,V>>, Box<Trie<K,V>>),
+    Mapping(HashvalMask, Mapping<K,V>)
+}
+
+type HashvalMask = (Hashval, usize);
+
+enum Mapping<K,V> {
+    Empty, 
+    Here, 
+    There(Art<Chunk<K, V>>),
+}
+
+pub struct Chunk<K,V> {
+    here: Vec<(K, V)>,
+    there: Trie<K, V>,
+    prev: Art<Chunk<K, V>>
+}
+
+pub fn emp
+    <K:'static+Hash+PartialEq+Eq+Clone+Debug,
+     V:'static+Hash+PartialEq+Eq+Clone+Debug>
+    () -> Log<K,V> { 
+        Log::Empty
+    }
+
+pub fn put
+    <K:'static+Hash+PartialEq+Eq+Clone+Debug,
+     V:'static+Hash+PartialEq+Eq+Clone+Debug>
+    (an:Option<Name>, log:Log<K,V>, k:K, v:V) -> Log<K,V> {
+        unimplemented!()
+    }
+
+pub fn get
+    <K:'static+Hash+PartialEq+Eq+Clone+Debug,
+     V:'static+Hash+PartialEq+Eq+Clone+Debug>
+    (an:Option<Name>, log:Log<K,V>, k:K) -> (Log<K,V>, Option<V>) {
+        unimplemented!()
+    }
+
+pub fn into_trie
+    <K:'static+Hash+PartialEq+Eq+Clone+Debug,
+     V:'static+Hash+PartialEq+Eq+Clone+Debug>
+    (trie:Log<K,V>) -> trie2::Trie<K,V> {
+        unimplemented!()
+    }

--- a/src/kvlog.rs
+++ b/src/kvlog.rs
@@ -1,6 +1,7 @@
 use std::fmt;
 use std::fmt::Debug;
 use std::hash::{Hash, Hasher};
+use std::collections::hash_map::HashMap;
 
 use adapton::engine::*;
 use trie2;
@@ -8,122 +9,45 @@ use trie2;
 #[derive(Clone,PartialEq,Eq,Debug,Hash)]
 struct Hashval ( u64 );
 
-pub type Log<K,V> = Option<Chunk<K, V>>;
-
 #[derive(Clone,PartialEq,Eq,Debug,Hash)]
-enum Trie<K,V> {
-    Bin(Box<Trie<K,V>>, Box<Trie<K,V>>),
-    Mapping(HashvalMask, Mapping<K,V>)
-}
+pub struct Log<K,V> ( Option<Chunk<K, V>> );
 
 type HashvalMask = (Hashval, usize);
 
-#[derive(Clone,PartialEq,Eq,Debug,Hash)]
-enum Mapping<K,V> {
-    Empty,
-    Here,
-    There(Art<Chunk<K, V>>),
-}
-
-#[derive(Clone,PartialEq,Eq,Debug,Hash)]
+#[derive(Clone,PartialEq,Eq,Debug)]
 pub struct Chunk<K,V> {
     here: Vec<(K, V)>,
-    there: Option<Trie<K, V>>,
-    prev: Option<Art<Chunk<K,V>>>,
+    there: JumpTable<K, V>,
+    prev: Option<Art<Chunk<K, V>>>,
 }
 
-pub fn emp
-    <K:'static+Hash+PartialEq+Eq+Clone+Debug,
-     V:'static+Hash+PartialEq+Eq+Clone+Debug>
-    () -> Log<K,V> { None }
+type JumpTable<K,V> = HashMap<usize,Option<Art<Chunk<K,V>>>> ;
 
-fn compute_trie
-    <K:'static+Hash+PartialEq+Eq+Clone+Debug,
-     V:'static+Hash+PartialEq+Eq+Clone+Debug>
-    (log:Log<K,V>) -> Log<K,V> {
-        match log {
-            None => None,
-            Some(chunk) => {
-                // compute 'there' trie for the key-value pairs that
-                // are 'here' in the chunk.
-                unimplemented!()
-            }
+impl<K:Hash,V:Hash> Hash for Chunk<K,V> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.here.hash(state);
+        self.prev.hash(state);        
+        for (ref bits, ref opart) in self.there.iter() {
+            bits.hash(state);
+            opart.hash(state);
         }
     }
+}
 
-pub fn archive
-    <K:'static+Hash+PartialEq+Eq+Clone+Debug,
-     V:'static+Hash+PartialEq+Eq+Clone+Debug>
-    (an:Option<Name>, log:Log<K,V>) -> Log<K,V> {
-        match an {
-            None => log,
-            Some(n) => {
-                let log = compute_trie(log);
-                Some(Chunk{
-                    here: Vec::new(),
-                    there: None,
-                    prev: match log {
-                        None => None,
-                        Some(c) => Some(cell(n, c))
-                    }
-                })
-            }
-        }
-    }
+impl <K:'static+Hash+PartialEq+Eq+Clone+Debug,
+      V:'static+Hash+PartialEq+Eq+Clone+Debug> Log<K,V> {
 
-pub fn put
-    <K:'static+Hash+PartialEq+Eq+Clone+Debug,
-     V:'static+Hash+PartialEq+Eq+Clone+Debug>
-    (an:Option<Name>, log:Log<K,V>, k:K, v:V) -> Log<K,V> {
-        let mut log = archive(an, log);
-        match log {
-            None =>
-                return Some(Chunk{
-                    here: vec![(k,v)],
-                    there: None,
-                    prev: None,
-                }),
-            Some(ref mut c) => {
-                c.here.push((k,v));
-            }
-        };
-        return log
-    }
+    pub fn emp() -> Log<K,V> { Log(None) }
 
-pub fn chunk_find
-    <K:'static+Hash+PartialEq+Eq+Clone+Debug,
-     V:'static+Hash+PartialEq+Eq+Clone+Debug>
-    (c:&Chunk<K,V>, k:&K) -> Option<V> {
-        for &(ref ck, ref cv) in c.here.iter() /* FIXME: reverse! */ {
-            if k == ck { return Some(cv.clone()); }
-        };
-        // Do a look-up in the Trie 'there', to find the next
-        // Chunk to search with a linear scan (as above).
+    pub fn put(&mut self, key: K, val: V) {
         unimplemented!()
     }
 
-
-pub fn get
-    <K:'static+Hash+PartialEq+Eq+Clone+Debug,
-     V:'static+Hash+PartialEq+Eq+Clone+Debug>
-    (an:Option<Name>, mut log:Log<K,V>, k:&K) -> (Log<K,V>, Option<V>) {
-        match log {
-            None => (None, None),
-            Some(c) => {
-                let ret = chunk_find(&c, &k);
-                // if value is found, record it 'here', otherwise, record nothing in log.
-                match ret {
-                    None =>        { log = Some(c) },
-                    Some(ref v) => { log = put(an, Some(c), k.clone(), v.clone()) }
-                };
-                (log, ret)
-            }
-        }
-    }
-
-pub fn into_trie
-    <K:'static+Hash+PartialEq+Eq+Clone+Debug,
-     V:'static+Hash+PartialEq+Eq+Clone+Debug>
-    (trie:Log<K,V>) -> trie2::Trie<K,V> {
+    pub fn get(&mut self, key: K) -> Option<V> {
         unimplemented!()
     }
+
+    pub fn into_trie(self) -> trie2::Trie<K,V> {
+        unimplemented!()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,3 +59,4 @@ pub type ArchiveStack<E> = archive_stack::AStack<E,()>;
 pub fn inc_level() -> u32 {
   level_tree::gen_branch_level(&mut rand::thread_rng())
 }
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,8 @@ pub mod skiplist;
 pub mod trie1;
 pub mod trie2;
 
+pub mod kvlog;
+
 /// Gauged Incremental Raz with element counts
 pub type IRaz<E> = raz::Raz<E,raz_meta::Count>;
 pub type Giraz<E> = raz::Raz<E,raz_meta::Count>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,8 @@ pub mod finite_map;
 //#[doc(hidden)]
 pub mod skiplist;
 #[doc(hidden)]
-//pub mod trie;
+
+pub mod trie1;
 pub mod trie2;
 
 /// Gauged Incremental Raz with element counts

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,7 @@ pub mod finite_map;
 pub mod skiplist;
 //#[doc(hidden)]
 pub mod trie;
+pub mod trie2;
 
 /// Gauged Incremental Raz with element counts
 pub type IRaz<E> = raz::Raz<E,raz_meta::Count>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@ pub mod finite_map;
 // Two forms of tries. They work, but performance needs improvement
 #[doc(hidden)]
 pub mod skiplist;
-#[doc(hidden)]
+//#[doc(hidden)]
 pub mod trie;
 
 /// Gauged Incremental Raz with element counts

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,10 +39,10 @@ pub mod raz_based;      // Some simple structs based on the Raz
 pub mod finite_map;
 
 // Two forms of tries. They work, but performance needs improvement
-#[doc(hidden)]
-pub mod skiplist;
 //#[doc(hidden)]
-pub mod trie;
+pub mod skiplist;
+#[doc(hidden)]
+//pub mod trie;
 pub mod trie2;
 
 /// Gauged Incremental Raz with element counts

--- a/src/trie.rs
+++ b/src/trie.rs
@@ -129,6 +129,26 @@ impl<K:'static+Hash+Eq+Clone+Debug,
         Trie{gauge:gauge, rec:TrieRec::Empty}
     }
 
+    pub fn from_vec(vec:&Vec<(K,V)>) -> Self { 
+        let mut hm = HashMap::new();
+        for &(ref k, ref v) in vec.iter() {
+            let k_hash = my_hash(k);
+            hm.insert(k.clone(),(k_hash,v.clone()));
+        };
+        Trie{gauge:hm.len(), 
+             rec:TrieRec::Leaf(TrieLeaf{map:hm})}
+    }
+
+    pub fn from_key_vec(vec:&Vec<K>) -> Trie<K,()> { 
+        let mut hm = HashMap::new();
+        for k in vec.iter() {
+            let k_hash = my_hash(k);
+            hm.insert(k.clone(),(k_hash,()));
+        };
+        Trie{gauge:hm.len(), 
+             rec:TrieRec::Leaf(TrieLeaf{map:hm})}
+    }
+
     pub fn from_hashmap(hm:HashMap<K,(HashVal,V)>) -> Self { 
         Trie{gauge:hm.len(), 
              rec:TrieRec::Leaf(TrieLeaf{map:hm})}

--- a/src/trie.rs
+++ b/src/trie.rs
@@ -44,70 +44,65 @@ fn make_mask(len:usize) -> usize {
 #[derive(PartialEq,Eq,Clone,Debug,Hash)]
 struct Bits {bits:u32, len:u32}
 
+#[derive(PartialEq,Eq,Clone,Debug,Hash)]
+pub struct Trie
+    <K:'static+Hash+Eq+Clone+Debug,
+     V:'static+Hash+Eq+Clone+Debug>
+{
+    gauge:usize,
+    rec:TrieRec<K,V>,
+}
+
 #[derive(PartialEq,Eq,Clone,Debug, Hash)]
-pub enum Trie<K:'static+Hash+Eq+Clone+Debug,
-              V:'static+Hash+Eq+Clone+Debug>
+enum TrieRec<K:'static+Hash+Eq+Clone+Debug,
+             V:'static+Hash+Eq+Clone+Debug>
 {
     Empty,
     Leaf(TrieLeaf<K,V>),
     Bin(TrieBin<K,V>),
 }
-#[derive(Eq,Clone,Debug)]
-pub struct TrieLeaf<K:'static+Hash+Eq+Clone+Debug,
-                    V:'static+Hash+Eq+Clone+Debug> {
-    hash:HashVal,
+#[derive(PartialEq,Eq,Clone,Debug)]
+struct TrieLeaf<K:'static+Hash+Eq+Clone+Debug,
+                V:'static+Hash+Eq+Clone+Debug> {
     map:HashMap<K,V>,
 }
 #[derive(Hash,PartialEq,Eq,Clone,Debug)]
-pub struct TrieBin<K:'static+Hash+Eq+Clone+Debug,
-                   V:'static+Hash+Eq+Clone+Debug> {
+struct TrieBin<K:'static+Hash+Eq+Clone+Debug,
+               V:'static+Hash+Eq+Clone+Debug> {
     bits:   Bits,
     name:   Name,
-    left:   Art<Trie<K,V>>,
-    right:  Art<Trie<K,V>>,
+    left:   Art<TrieRec<K,V>>,
+    right:  Art<TrieRec<K,V>>,
 }
 
 impl<K:'static+Hash+Eq+Clone+Debug,
      V:'static+Hash+Eq+Clone+Debug>
     Hash for TrieLeaf<K,V> 
 {
-    fn hash<H:Hasher>(&self, h:&mut H) {
-        self.hash.hash(h)
-    }
-}
-impl<K:'static+Hash+Eq+Clone+Debug,
-     V:'static+Hash+Eq+Clone+Debug>
-    PartialEq for TrieLeaf<K,V> 
-{
-    fn eq(&self, other:&Self) -> bool {
-        self.hash == other.hash
+    fn hash<H:Hasher>(&self, _h:&mut H) {
+        unimplemented!()
     }
 }
 
 impl<K:'static+Hash+Eq+Clone+Debug,
      V:'static+Hash+Eq+Clone+Debug> Trie<K,V> {
 
-    pub fn find (t: &Self, h:HashVal, k:&K) -> Option<V> {
-        match t {
-            &Trie::Empty => None,
-            &Trie::Leaf(ref l) => match l.map.get(k) { Some(v) => Some(v.clone()), None => None },
-            &Trie::Bin(ref b) => {
+    pub fn find (t: &Trie<K,V>, h:HashVal, k:&K) -> Option<V> {
+        Self::find_rec(t, &t.rec, h, k)
+    }
+
+    fn find_rec (t: &Trie<K,V>, r:&TrieRec<K,V>, h:HashVal, k:&K) -> Option<V> {
+        match r {
+            &TrieRec::Empty => None,
+            &TrieRec::Leaf(ref l) => match l.map.get(k) { Some(v) => Some(v.clone()), None => None },
+            &TrieRec::Bin(ref b) => {
                 if h.0 & 1 == 0 {
-                    Self::find(&get!(b.left), HashVal(h.0 >> 1), k)
+                    Self::find_rec(t, &get!(b.left), HashVal(h.0 >> 1), k)
                 } else { 
-                    Self::find(&get!(b.right), HashVal(h.0 >> 1), k)
+                    Self::find_rec(t, &get!(b.right), HashVal(h.0 >> 1), k)
                 }
             }
         }
-    }
-
-    fn hash_map (map: &HashMap<K,V>) -> HashVal {
-        let mut state = DefaultHasher::new();
-        for (k,v) in map.iter() {
-            k.hash(&mut state);
-            v.hash(&mut state);
-        };
-        HashVal(state.finish() as usize)
     }
 
     fn split_map (map: HashMap<K,V>, bits:&Bits,
@@ -128,74 +123,114 @@ impl<K:'static+Hash+Eq+Clone+Debug,
         (map0, map1)
     }
 
-    pub fn empty () -> Self { 
-        Trie::Empty 
+    pub fn empty (gauge:usize) -> Self { 
+        Trie{gauge:gauge, rec:TrieRec::Empty}
     }
 
     pub fn from_hashmap(hm:HashMap<K,V>) -> Self { 
-        Trie::Leaf(TrieLeaf{hash:Self::hash_map(&hm), map:hm})
+        Trie{gauge:hm.len(), 
+             rec:TrieRec::Leaf(TrieLeaf{map:hm})}
     }
 
-    pub fn union (lt: Self, rt: Self, n:Name) -> Self {
-        Self::union_rec(lt, rt, Bits{len:0, bits:0}, n)
+    pub fn join (lt: Self, rt: Self, n:Name) -> Self {
+        assert_eq!(lt.gauge, rt.gauge); // ??? -- Or take the min? Or the max? Or the average?
+        let lt_rec = lt.rec;
+        let lt = Trie{rec:TrieRec::Empty, .. lt};
+        Trie{rec:Self::join_rec(&lt, lt_rec, rt.rec, Bits{len:0, bits:0}, n),..lt}
     }
 
-    // Questions:
-    //
-    // 1. When do we decide to "merge" leaves?  Based on where we have
-    // or don't have names/levels?
-    //
-    // 2. Is there a way to shorten the code below? There seems to be
-    // patterns that I'm not exploiting.
+    fn split_bits (bits:&Bits) -> (Bits, Bits) {
+        let lbits = Bits{len:bits.len+1, bits: bits.bits };
+        let rbits = Bits{len:bits.len+1, bits:(1 << bits.len) & bits.bits };
+        (lbits, rbits)
+    }
 
-    fn union_rec (lt: Self, rt: Self, bits:Bits, n:Name) -> Self {
+    fn join_rec (t:&Trie<K,V>, lt: TrieRec<K,V>, rt: TrieRec<K,V>, bits:Bits, n:Name) -> TrieRec<K,V> {
         match (lt, rt) {
-            (Trie::Empty, rt) => rt,
-            (lt, Trie::Empty) => lt,
-            (Trie::Leaf(l), Trie::Leaf(r)) => {
+            (TrieRec::Empty, rt) => rt,
+            (lt, TrieRec::Empty) => lt,
+            (TrieRec::Leaf(mut l), TrieRec::Leaf(r)) => {
+                if l.map.len() + r.map.len() < t.gauge {
+                    // Sub-Case: the leaves, when combined, are smaller than the gauge.
+                    for (k,v) in r.map.into_iter() { l.map.insert(k,v); }
+                    TrieRec::Leaf(l)
+                } else {
+                    // Sub-Case: the leaves are large enough to justify not being combined.
+                    let (lb, rb) = Self::split_bits(&bits);
+                    let (e0, e1) = (HashMap::new(), HashMap::new());
+                    let (l0, l1) = Self::split_map(l.map, &lb, e0, e1);
+                    let (r0, r1) = Self::split_map(r.map, &rb, l0, l1);
+                    let (n1, n2) = name_fork(n.clone());
+                    let r0 = cell(n1, TrieRec::Leaf(TrieLeaf{map:r0}));
+                    let r1 = cell(n2, TrieRec::Leaf(TrieLeaf{map:r1}));
+                    TrieRec::Bin(TrieBin{left:r0, right:r1, bits:bits, name:n})
+                }
+            },
+            (TrieRec::Leaf(l), TrieRec::Bin(r)) => {
                 let (e0, e1) = (HashMap::new(), HashMap::new());
                 let (l0, l1) = Self::split_map(l.map, &bits, e0, e1);
-                let (r0, r1) = Self::split_map(r.map, &bits, l0, l1);
+                let (lb, rb) = Self::split_bits(&bits);
                 let (n1, n2) = name_fork(n.clone());
-                let lf1 = TrieLeaf{hash:Self::hash_map(&r0), map:r0};
-                let lf2 = TrieLeaf{hash:Self::hash_map(&r1), map:r1};
-                let r0 = cell(n1, Trie::Leaf(lf1));
-                let r1 = cell(n2, Trie::Leaf(lf2));
-                Trie::Bin(TrieBin{left:r0, right:r1, bits:bits, name:n})
+                let (m0, m1) = name_fork(r.name.clone());
+                let ol = cell(n1, Self::join_rec(t, TrieRec::Leaf(TrieLeaf{map:l0}), get!(r.left),  lb, m0));
+                let or = cell(n2, Self::join_rec(t, TrieRec::Leaf(TrieLeaf{map:l1}), get!(r.right), rb, m1));
+                TrieRec::Bin(TrieBin{ left:ol, right:or, name:n, bits:bits })
             },
-            (Trie::Leaf(_l), Trie::Bin(_r)) => {
-                panic!("TODO")
-                /*
-                assert!(r.bits == bits);
-                let lbits = Bits{len:bits.len+1, bits: bits.bits };
-                let rbits = Bits{len:bits.len+1, bits:(1 << bits.len) & bits.bits };
-                let (e0, e1) = (HashMap::new(), HashMap::new());
-                let (l0, l1) = Self::split_map(l.map, &bits, e0, e1);
-                let lf0 = TrieLeaf{hash:Self::hash_map(&l0), map:l0};
-                let lf1 = TrieLeaf{hash:Self::hash_map(&l1), map:l1};
-                let (n1, n2) = name_fork(n.clone());
-
-                let l = cell(n1, Self::union_rec(TrieLeaf{, get!(l.right), lbits, l.name));
-                let r = cell(n2, Self::union_rec(get!(r.left), get!(r.right), rbits, r.name));
-                */
-            },
-            (Trie::Bin(_l), Trie::Leaf(r)) => {
+            (TrieRec::Bin(l), TrieRec::Leaf(r)) => {
                 let (e0, e1) = (HashMap::new(), HashMap::new());
                 let (r0, r1) = Self::split_map(r.map, &bits, e0, e1);
-                
-                drop((r0, r1));
-                panic!("")
+                let (lb, rb) = Self::split_bits(&bits);
+                let (n1, n2) = name_fork(n.clone());
+                let (m0, m1) = name_fork(l.name.clone());
+                let ol = cell(n1, Self::join_rec(t, get!(l.left),  TrieRec::Leaf(TrieLeaf{map:r0}), lb, m0));
+                let or = cell(n2, Self::join_rec(t, get!(l.right), TrieRec::Leaf(TrieLeaf{map:r1}), rb, m1));
+                TrieRec::Bin(TrieBin{ left:ol, right:or, name:n, bits:bits })
             },
-            (Trie::Bin(l), Trie::Bin(r)) => {
+            (TrieRec::Bin(l), TrieRec::Bin(r)) => {
                 assert!(l.bits == bits);
                 assert!(l.bits == r.bits);
-                let lbits = Bits{len:bits.len+1, bits: bits.bits };
-                let rbits = Bits{len:bits.len+1, bits:(1 << bits.len) & bits.bits };
                 let (n1, n2) = name_fork(n.clone());
-                let l = cell(n1, Self::union_rec(get!(l.left), get!(l.right), lbits, l.name));
-                let r = cell(n2, Self::union_rec(get!(r.left), get!(r.right), rbits, r.name));
-                Trie::Bin(TrieBin{ left:l, right:r, name:n, bits:bits })
+                let (lb, rb) = Self::split_bits(&bits);
+                let ol = cell(n1, Self::join_rec(t, get!(l.left),  get!(r.left),  lb, l.name));
+                let or = cell(n2, Self::join_rec(t, get!(l.right), get!(r.right), rb, r.name));
+                TrieRec::Bin(TrieBin{ left:ol, right:or, name:n, bits:bits })
             }
         }
     }               
+}
+
+fn at_leaf(v:&Vec<usize>) -> Trie<usize,()> {
+    let mut hm = HashMap::new();
+    for x in v { hm.insert(*x,()); }
+    Trie::from_hashmap(hm)
+}
+
+fn at_bin(l:Trie<usize,()>,lev:u32,n:Option<Name>,r:Trie<usize,()>) -> Trie<usize,()> {
+    Trie::join(l,r,n.unwrap())
+}
+
+#[test]
+pub fn test_join () {
+    use rand::{thread_rng,Rng};
+    use adapton::engine::*;
+    use archive_stack::*;
+    use raz::*;
+    use memo::*;
+    use level_tree::*;
+    use raz_meta::Count;
+    use std::rc::Rc;
+
+    let mut rng = thread_rng();
+
+    let mut elms : AStack<usize,_> = AStack::new();
+    for i in 0..10000 {
+        let elm = rng.gen::<usize>();
+        elms.push(elm);
+        if i % 10 == 0 {
+            elms.archive(Some(name_of_usize(i)), gen_branch_level(&mut rng));
+        }
+    }
+    let tree: RazTree<_,Count> = RazTree::memo_from(&AtHead(elms));
+    let trie = tree.fold_up_gauged(Rc::new(at_leaf),Rc::new(at_bin));
+
 }

--- a/src/trie.rs
+++ b/src/trie.rs
@@ -146,7 +146,7 @@ impl<K:'static+Hash+Eq+Clone+Debug,
 
     fn split_bits (bits:&Bits) -> (Bits, Bits) {
         let lbits = Bits{len:bits.len+1, bits: bits.bits };
-        let rbits = Bits{len:bits.len+1, bits:(1 << bits.len) & bits.bits };
+        let rbits = Bits{len:bits.len+1, bits:(1 << bits.len) | bits.bits };
         (lbits, rbits)
     }
 

--- a/src/trie.rs
+++ b/src/trie.rs
@@ -8,10 +8,175 @@
 use std::fmt;
 use std::fmt::Debug;
 use std::hash::{Hash,Hasher};
-use std::collections::HashMap;
+//use std::collections::HashMap;
 use std::collections::hash_map::DefaultHasher;
 use adapton::engine::*;
 use adapton::macros::*;
+
+pub mod hammer_level_tree {
+    use std::fmt::Debug;
+    use std::hash::{Hash};
+    use adapton::macros::*;
+    use adapton::engine::{Name,Art,cell,force,thunk,ArtIdChoice};
+    use raz::RazTree;
+    use raz_meta::Count;
+
+    #[derive(Clone,PartialEq,Eq,Debug,Hash)]
+    struct BinCons<X> {
+        level: u32,
+        recl:Box<Rec<X>>,
+        recr:Box<Rec<X>>
+    }
+    #[derive(Clone,PartialEq,Eq,Debug,Hash)]
+    struct NameCons<X> {
+        level:u32,
+        name:Name,
+        rec:Box<Rec<X>>,
+    }
+    #[derive(Clone,PartialEq,Eq,Debug,Hash)]
+    struct LeafCons<X> {
+        elms:Vec<X>,
+    }
+    #[derive(Clone,PartialEq,Eq,Debug,Hash)]
+    enum Rec<X> {
+        Leaf(LeafCons<X>),
+        Bin(BinCons<X>),
+        Name(NameCons<X>),
+        Art(Art<Rec<X>>),
+    }
+    #[derive(Clone,PartialEq,Eq,Debug,Hash)]
+    pub struct LevTree<X> {
+        rec:Rec<X>
+    }
+
+    impl<X:'static+Clone+PartialEq+Eq+Debug+Hash> 
+        LevTree<X> 
+    {
+        pub fn leaf(xs:Vec<X>) -> Self { 
+            LevTree{rec:Rec::Leaf(LeafCons{elms:xs})} 
+        }
+        pub fn bin(lev:u32, l:Self, r:Self) -> Self { 
+            LevTree{rec:Rec::Bin(BinCons{level:lev,recl:Box::new(l.rec),recr:Box::new(r.rec)})} 
+        }
+        pub fn name(lev:u32, n:Name, r:Self) -> Self {
+            LevTree{rec:Rec::Name(NameCons{level:lev,name:n, rec:Box::new(r.rec)}) }
+        }
+        fn art(a:Art<Rec<X>>) -> Self {
+            LevTree{rec:Rec::Art(a)}
+        }
+        pub fn fold_monoid<B:'static+Clone+PartialEq+Eq+Debug+Hash>
+            (t:LevTree<X>, z:X, b:B, bin:fn(B,X,X)->X, art:fn(Art<X>,X)->X) -> X {
+                fn m_leaf<B:Clone,X>(m:(B,fn(B,X,X)->X,X), elms:Vec<X>) -> X { 
+                    let mut x = m.2;
+                    for elm in elms { x=m.1(m.0.clone(), x, elm) };
+                    x
+                }
+                fn m_bin<B,X>(m:(B,fn(B,X,X)->X,X), _lev:u32, _n:Option<Name>, l:X, r:X) -> X { 
+                    m.1(m.0, l, r)
+                }
+                Self::fold_up_namebin::<(B,fn(B,X,X)->X,X),
+                                        (B,fn(B,X,X)->X,X),X>
+                    (t,
+                     (b.clone(),bin,z.clone()), m_leaf,
+                     (b,bin,z), m_bin, 
+                     art)
+            }
+
+        pub fn fold_up
+            <L:'static+Clone+PartialEq+Eq+Debug+Hash,
+             B:'static+Clone+PartialEq+Eq+Debug+Hash,
+             N:'static+Clone+PartialEq+Eq+Debug+Hash,
+             R:'static+Clone+PartialEq+Eq+Debug+Hash>
+            (t:LevTree<X>, 
+             l:L, leaf:fn(L,Vec<X>)->R, 
+             b:B, bin:fn(B,u32,R,R)->R,
+             n:N, name:fn(N,u32,Name,R)->R) -> R {
+                Self::fold_up_rec(t.rec, l, leaf, b, bin, n, name)
+            }
+        
+        fn fold_up_rec<L:'static+Clone+PartialEq+Eq+Debug+Hash,
+                       B:'static+Clone+PartialEq+Eq+Debug+Hash,
+                       N:'static+Clone+PartialEq+Eq+Debug+Hash,
+                       R:'static+Clone+PartialEq+Eq+Debug+Hash>
+            (t:Rec<X>, 
+             l:L, leaf:fn(L,Vec<X>)->R, 
+             b:B, bin:fn(B,u32,R,R)->R,
+             n:N, name:fn(N,u32,Name,R)->R) -> R {
+                match t {
+                    Rec::Art(a) => Self::fold_up_rec(get!(a), l, leaf, b, bin, n, name),
+                    Rec::Leaf(leafcons) => leaf(l, leafcons.elms),
+                    Rec::Bin(bincons)   => {
+                        let r1 = Self::fold_up_rec(*bincons.recl, l.clone(), leaf, b.clone(), bin, n.clone(), name);
+                        let r2 = Self::fold_up_rec(*bincons.recr, l.clone(), leaf, b.clone(), bin, n.clone(), name);
+                        bin(b, bincons.level, r1, r2)
+                    }
+                    Rec::Name(namecons) => {
+                        let r = Self::fold_up_rec(*namecons.rec, l, leaf, b, bin, n.clone(), name);
+                        name(n, namecons.level, namecons.name, r)
+                    }
+                }
+            }
+
+        pub fn fold_up_namebin
+            <L:'static+Clone+PartialEq+Eq+Debug+Hash,
+             B:'static+Clone+PartialEq+Eq+Debug+Hash,
+             R:'static+Clone+PartialEq+Eq+Debug+Hash>
+            (t:LevTree<X>, 
+             l:L, leaf:fn(L,Vec<X>)->R, 
+             b:B, namebin:fn(B,u32,Option<Name>,R,R)->R, 
+             art:fn(Art<R>,R)->R) -> R {
+                Self::fold_up_namebin_rec(t.rec, l, leaf, b, None, namebin, art)
+            }
+        
+        fn fold_up_namebin_rec
+            <L:'static+Clone+PartialEq+Eq+Debug+Hash,
+             B:'static+Clone+PartialEq+Eq+Debug+Hash,
+             R:'static+Clone+PartialEq+Eq+Debug+Hash>             
+            (t:Rec<X>,
+             l:L, leaf:fn(L,Vec<X>)->R,
+             b:B, n:Option<Name>,
+             namebin:fn(B,u32,Option<Name>,R,R)->R,
+             art:fn(Art<R>,R)->R) -> R {
+                match t {
+                    Rec::Art(a) => Self::fold_up_namebin_rec(get!(a), l, leaf, b, n, namebin, art),
+                    Rec::Leaf(leafcons) => leaf(l, leafcons.elms),
+                    Rec::Bin(bincons)   => {
+                        let r1 = Self::fold_up_namebin_rec(*bincons.recl, l.clone(), leaf, b.clone(), None, namebin, art);
+                        let r2 = Self::fold_up_namebin_rec(*bincons.recr, l.clone(), leaf, b.clone(), None, namebin, art);
+                        namebin(b, bincons.level, n, r1, r2)
+                    }
+                    Rec::Name(namecons) => {
+                        let (a,x) = eager!( 
+                            namecons.name.clone() =>> Self::fold_up_namebin_rec,
+                            t:*namecons.rec, 
+                            l:l, leaf:leaf,
+                            b:b, n:Some(namecons.name), namebin:namebin, art:art 
+                        );
+                        art(a,x)
+                    }
+                }
+            }
+        
+        pub fn from_raz_tree(t:RazTree<X,Count>) -> LevTree<X> {
+            fn at_leaf<X:'static+Clone+PartialEq+Eq+Debug+Hash>
+                (v:&Vec<X>) -> LevTree<X> {
+                    LevTree::leaf(v.clone())
+                }
+            fn at_bin<X:'static+Clone+PartialEq+Eq+Debug+Hash>
+                (l:LevTree<X>,lev:u32,n:Option<Name>,r:LevTree<X>) -> LevTree<X> {
+                    match n {
+                        None => LevTree::bin(lev,l,r),
+                        Some(n) => {
+                            let n_ = n.clone();
+                            let a = LevTree::art(cell(n_, LevTree::bin(lev, l, r).rec));
+                            LevTree::name(lev, n, a)
+                        }
+                    }
+                }
+            t.fold_up_gauged(Rc::new(at_leaf), Rc::new(at_bin)).unwrap()
+        }
+    }
+}
 
 fn my_hash<T>(obj: T) -> HashVal
   where T: Hash
@@ -42,8 +207,8 @@ impl fmt::Debug for Bits {
 
 #[derive(PartialEq,Eq,Clone,Debug,Hash)]
 pub struct Trie
-    <K:'static+Hash+Eq+Clone+Debug,
-     V:'static+Hash+Eq+Clone+Debug>
+    <K:'static+Hash+PartialEq+Eq+Clone+Debug,
+     V:'static+Hash+PartialEq+Eq+Clone+Debug>
 {
     meta:TrieMeta,
     rec:TrieRec<K,V>,
@@ -54,81 +219,86 @@ pub struct TrieMeta {
     gauge:usize,
 }
 
-#[derive(PartialEq,Eq,Clone,Debug, Hash)]
-enum TrieRec<K:'static+Hash+Eq+Clone+Debug,
-             V:'static+Hash+Eq+Clone+Debug>
+#[derive(PartialEq,Eq,Clone,Debug,Hash)]
+pub enum TrieRec<K:'static+Hash+PartialEq+Eq+Clone+Debug,
+             V:'static+Hash+PartialEq+Eq+Clone+Debug>
 {
     Empty,
     Leaf(TrieLeaf<K,V>),
     Bin(TrieBin<K,V>),
+    Name(TrieName<K,V>),
+    Art(Art<TrieRec<K,V>>),
 }
-#[derive(PartialEq,Eq,Clone,Debug)]
-struct TrieLeaf<K:'static+Hash+Eq+Clone+Debug,
-                V:'static+Hash+Eq+Clone+Debug> {
-    map:HashMap<K,(HashVal,V)>,
+#[derive(PartialEq,Eq,Clone,Debug,Hash)]
+pub struct TrieLeaf<K:'static+Hash+PartialEq+Eq+Clone+Debug,
+                    V:'static+Hash+PartialEq+Eq+Clone+Debug> {
+    kvs:Rc<Vec<(K,HashVal,V)>>,
 }
 #[derive(Hash,PartialEq,Eq,Clone,Debug)]
-struct TrieBin<K:'static+Hash+Eq+Clone+Debug,
-               V:'static+Hash+Eq+Clone+Debug> {
+pub struct TrieBin<K:'static+Hash+PartialEq+Eq+Clone+Debug,
+                   V:'static+Hash+PartialEq+Eq+Clone+Debug> {
     bits:   Bits,
+    left:   Box<TrieRec<K,V>>,
+    right:  Box<TrieRec<K,V>>,
+}
+#[derive(Hash,PartialEq,Eq,Clone,Debug)]
+pub struct TrieName<K:'static+Hash+PartialEq+Eq+Clone+Debug,
+                    V:'static+Hash+PartialEq+Eq+Clone+Debug> {
     name:   Name,
-    left:   Art<TrieRec<K,V>>,
-    right:  Art<TrieRec<K,V>>,
+    rec:    Box<TrieRec<K,V>>,
 }
 
-impl<K:'static+Hash+Eq+Clone+Debug,
-     V:'static+Hash+Eq+Clone+Debug>
-    Hash for TrieLeaf<K,V> 
-{
-    fn hash<H:Hasher>(&self, _h:&mut H) {
-        unimplemented!()
-    }
-}
-
-impl<K:'static+Hash+Eq+Clone+Debug,
-     V:'static+Hash+Eq+Clone+Debug> Trie<K,V> {
+impl<K:'static+Hash+PartialEq+Eq+Clone+Debug,
+     V:'static+Hash+PartialEq+Eq+Clone+Debug> Trie<K,V> {
 
     pub fn find (&self, k:&K) -> Option<V> {
         Self::find_hash(self, my_hash(k), k)
     }
 
     pub fn find_hash (t: &Trie<K,V>, h:HashVal, k:&K) -> Option<V> {
-        Self::find_rec(t, &t.rec, h, k)
+        Self::find_rec(t, &t.rec, h.clone(), h, k)
     }
 
-    fn find_rec (t: &Trie<K,V>, r:&TrieRec<K,V>, h:HashVal, k:&K) -> Option<V> {
+    fn find_rec (t: &Trie<K,V>, r:&TrieRec<K,V>, h:HashVal, h_rest:HashVal, k:&K) -> Option<V> {
         match r {
+            &TrieRec::Art(ref a) => Self::find_rec(t, &get!(a), h, h_rest, k),
+            &TrieRec::Name(ref n) => Self::find_rec(t, &*n.rec, h, h_rest, k),
             &TrieRec::Empty => None,
-            &TrieRec::Leaf(ref l) => match l.map.get(k) { 
-                None => None,
-                Some(&(_,ref v)) => Some(v.clone()),
+            &TrieRec::Leaf(ref l) => {
+                let mut ans = None;
+                for &(ref k2,ref k2_hash,ref v) in l.kvs.iter() {
+                    if k2_hash == &h && k2 == k {
+                        ans = Some(v.clone())
+                    }
+                }
+                return ans
             },
             &TrieRec::Bin(ref b) => {
-                if h.0 & 1 == 0 {
-                    Self::find_rec(t, &get!(b.left), HashVal(h.0 >> 1), k)
+                if h_rest.0 & 1 == 0 {
+                    Self::find_rec(t, &*b.left, h, HashVal(h_rest.0 >> 1), k)
                 } else { 
-                    Self::find_rec(t, &get!(b.right), HashVal(h.0 >> 1), k)
+                    Self::find_rec(t, &*b.right, h, HashVal(h_rest.0 >> 1), k)
                 }
             }
         }
     }
 
-    fn split_map (map: HashMap<K,(HashVal,V)>, 
+    fn split_vec (vec: Rc<Vec<(K,HashVal,V)>>,
                   bits_len:u32,
-                  mut map0:HashMap<K,(HashVal,V)>, 
-                  mut map1:HashMap<K,(HashVal,V)>)
-                  -> (HashMap<K,(HashVal,V)>, HashMap<K,(HashVal,V)>) 
+                  mut vec0:Vec<(K,HashVal,V)>, 
+                  mut vec1:Vec<(K,HashVal,V)>)
+                  -> (Vec<(K,HashVal,V)>, Vec<(K,HashVal,V)>)
     {
         //let mask : u64 = make_mask(bits_len as usize) as u64;
-        for (k,(k_hash,v)) in map.into_iter() {
+        for &(ref k, ref k_hash, ref v) in vec.iter() {
             //assert_eq!((mask & k_hash) >> 1, bits.bits as u64); // XXX/???
             if 0 == (k_hash.0 & (1 << bits_len)) {
-                map0.insert(k, (k_hash,v));
+                vec0.push((k.clone(),k_hash.clone(),v.clone()))
             } else {
-                map1.insert(k, (k_hash,v));
+                vec1.push((k.clone(),k_hash.clone(),v.clone()))
             }
         };
-        (map0, map1)
+        (vec0, vec1)
     }
 
     fn meta (gauge:usize) -> TrieMeta {
@@ -139,35 +309,40 @@ impl<K:'static+Hash+Eq+Clone+Debug,
         Trie{meta:Self::meta(gauge), rec:TrieRec::Empty}
     }
 
-    pub fn from_vec(vec:&Vec<(K,V)>) -> Self { 
-        let mut hm = HashMap::new();
-        for &(ref k, ref v) in vec.iter() {
+    pub fn from_vec(vec_in:&Vec<(K,V)>) -> Self { 
+        let mut vec = Vec::new();
+        for &(ref k, ref v) in vec_in.iter() {
             let k_hash = my_hash(k);
-            hm.insert(k.clone(),(k_hash,v.clone()));
+            vec.push((k.clone(),k_hash,v.clone()));
         };
-        Trie{meta:Self::meta(hm.len()), 
-             rec:TrieRec::Leaf(TrieLeaf{map:hm})}
+        Trie{meta:Self::meta(vec.len()), 
+             rec:TrieRec::Leaf(TrieLeaf{kvs:Rc::new(vec)})}
     }
 
-    pub fn from_key_vec(vec:&Vec<K>) -> Trie<K,()> { 
-        let mut hm = HashMap::new();
-        for k in vec.iter() {
+    pub fn from_key_vec_ref(vec_in:&Vec<K>) -> Trie<K,()> { 
+        let mut vec = Vec::new();
+        for k in vec_in.iter() {
             let k_hash = my_hash(k);
-            hm.insert(k.clone(),(k_hash,()));
+            vec.push((k.clone(),k_hash,()));
         };
-        Trie{meta:Self::meta(hm.len()), 
-             rec:TrieRec::Leaf(TrieLeaf{map:hm})}
+        Trie{meta:Self::meta(vec.len()), 
+             rec:TrieRec::Leaf(TrieLeaf{kvs:Rc::new(vec)})}
     }
 
-    pub fn from_hashmap(hm:HashMap<K,(HashVal,V)>) -> Self { 
-        Trie{meta:Self::meta(hm.len()), 
-             rec:TrieRec::Leaf(TrieLeaf{map:hm})}
+    pub fn from_key_vec(vec_in:Vec<K>) -> Trie<K,()> { 
+        let mut vec = Vec::new();
+        for k in vec_in {
+            let k_hash = my_hash(&k);
+            vec.push((k,k_hash,()));
+        };
+        Trie{meta:Self::meta(vec.len()), 
+             rec:TrieRec::Leaf(TrieLeaf{kvs:Rc::new(vec)})}
     }
 
-    pub fn join (lt: Self, rt: Self, n:Name) -> Self {
+    pub fn join (n:Option<Name>, lt: Self, rt: Self) -> Self {
         //assert_eq!(lt.gauge, rt.gauge); // ??? -- Or take the min? Or the max? Or the average?
         let gauge = if lt.meta.gauge > rt.meta.gauge { lt.meta.gauge } else { rt.meta.gauge };
-        Trie{rec:Self::join_rec(TrieMeta{gauge:gauge}, lt.rec, rt.rec, Bits{len:0, bits:0}, n),..lt}
+        Trie{rec:Self::join_rec(TrieMeta{gauge:gauge}, n, lt.rec, rt.rec, Bits{len:0, bits:0}),..lt}
     }
 
     fn split_bits (bits:&Bits) -> (Bits, Bits) {
@@ -176,55 +351,200 @@ impl<K:'static+Hash+Eq+Clone+Debug,
         (lbits, rbits)
     }
 
+    // TODO-Soon: Opt: After splitting a vec, create leaves by first checking whether the vec is empty.
+
+    fn leaf_or_empty (kvs:Vec<(K,HashVal,V)>) -> TrieRec<K,V> {
+        if kvs.len() == 0 { TrieRec::Empty }
+        else { TrieRec::Leaf(TrieLeaf{kvs:Rc::new(kvs)}) }
+    }
+
+    fn is_wf_rec (t:&TrieRec<K,V>, bits:Bits) -> bool {
+        match *t {
+            TrieRec::Art(ref a) => Self::is_wf_rec(&get!(a), bits),
+            TrieRec::Name(ref n) => Self::is_wf_rec(&*n.rec, bits),
+            TrieRec::Empty => true,
+            TrieRec::Leaf(ref leaf) => {
+                // Check that all of the hash values match the given bit pattern of bits.
+                for &(_,ref hv, _) in leaf.kvs.iter() {
+                    for i in 0..bits.len {
+                        if ((bits.bits & (1 << i)) as usize) == (hv.0 & (1 << i)) { continue }
+                        else { return false }
+                    }
+                }
+                return true
+            }
+            // Check bit patterns match, and that recursive trees are well-formed.
+            TrieRec::Bin(ref b) => { 
+                let (b0, b1) = Self::split_bits(&bits);
+                let lwf = Self::is_wf_rec(&*b.left, b0);
+                let rwf = Self::is_wf_rec(&*b.right, b1);
+                b.bits == bits && lwf && rwf 
+            }
+        }
+    }
+
+    fn is_wf(self:&Self) -> bool {
+        Self::is_wf_rec(&self.rec, Bits{bits:0, len:0})
+    }
+
+    fn join_rec (meta:TrieMeta, n:Option<Name>, lt: TrieRec<K,V>, rt: TrieRec<K,V>, bits:Bits) -> TrieRec<K,V> {
+        match n {
+            Some(n) => {
+                let (a,_trie) = eager!(n.clone() =>> Self::join_rec, meta:meta, n:None, lt:lt, rt:rt, bits:bits);
+                TrieRec::Name(TrieName{name:n, rec:Box::new(TrieRec::Art(a))})
+            },
+            None => { match (lt, rt) {
+                (TrieRec::Empty,   TrieRec::Empty)   => TrieRec::Empty,
+                (TrieRec::Empty,   TrieRec::Leaf(r)) => TrieRec::Leaf(r),
+                (TrieRec::Leaf(l), TrieRec::Empty  ) => TrieRec::Leaf(l),
+
+                (TrieRec::Name(l), TrieRec::Name(r)) => { Self::join_rec (meta, Some(l.name), *l.rec, *r.rec, bits) },
+
+                (TrieRec::Name(n), rt) => { Self::join_rec (meta, Some(n.name), *n.rec, rt, bits) },
+                (lt, TrieRec::Name(n)) => { Self::join_rec (meta, Some(n.name), lt, *n.rec, bits) },
+                
+                (TrieRec::Art(a), rt) => { Self::join_rec (meta, n, get!(a), rt, bits) },
+                (lt, TrieRec::Art(a)) => { Self::join_rec (meta, n, lt, get!(a), bits) },
+
+                (TrieRec::Leaf(l), TrieRec::Leaf(r)) => {
+                    if l.kvs.len() == 0 { 
+                        TrieRec::Leaf(r)
+                    } else if r.kvs.len() == 0 {
+                        TrieRec::Leaf(l)
+                    } else if l.kvs.len() + r.kvs.len() < meta.gauge {
+                        // Sub-Case: the leaves, when combined, are smaller than the gauge.
+                        let mut vec = (*l.kvs).clone();
+                        for &(ref k, ref k_hash, ref v) in r.kvs.iter() { 
+                            vec.push((k.clone(),k_hash.clone(),v.clone()));
+                        }
+                        Self::leaf_or_empty(vec)
+                    } else {
+                        // Sub-Case: the leaves are large enough to justify not being combined.
+                        let (e0, e1) = (Vec::new(), Vec::new());
+                        let (l0, l1) = Self::split_vec(l.kvs, bits.len, e0, e1);
+                        let (r0, r1) = Self::split_vec(r.kvs, bits.len, l0, l1);
+                        let t0 = Box::new(TrieRec::Leaf(TrieLeaf{kvs:Rc::new(r0)}));
+                        let t1 = Box::new(TrieRec::Leaf(TrieLeaf{kvs:Rc::new(r1)}));
+                        TrieRec::Bin(TrieBin{left:t0, right:t1, bits:bits})
+                    }
+                },
+                (TrieRec::Empty, TrieRec::Bin(r)) => {
+                    let (b0, b1) = Self::split_bits(&bits);
+                    let o0 = Self::join_rec(meta.clone(), None, TrieRec::Empty, *r.left, b0);
+                    let o1 = Self::join_rec(meta.clone(), None, TrieRec::Empty, *r.right, b1);
+                    TrieRec::Bin(TrieBin{ left:Box::new(o0), right:Box::new(o1), bits:bits })
+                },
+                (TrieRec::Leaf(l), TrieRec::Bin(r)) => {
+                    let (e0, e1) = (Vec::new(), Vec::new());
+                    let (l0, l1) = Self::split_vec(l.kvs, bits.len, e0, e1);
+                    let (b0, b1) = Self::split_bits(&bits);
+                    let o0 = Self::join_rec(meta.clone(), None, Self::leaf_or_empty(l0), *r.left, b0);
+                    let o1 = Self::join_rec(meta.clone(), None, Self::leaf_or_empty(l1), *r.right, b1);
+                    TrieRec::Bin(TrieBin{ left:Box::new(o0), right:Box::new(o1), bits:bits })
+                },
+                (TrieRec::Bin(l), TrieRec::Empty) => {
+                    let (b0, b1) = Self::split_bits(&bits);
+                    let o0 = Self::join_rec(meta.clone(), None, *l.left, TrieRec::Empty, b0);
+                    let o1 = Self::join_rec(meta.clone(), None, *l.right, TrieRec::Empty, b1);
+                    TrieRec::Bin(TrieBin{ left:Box::new(o0), right:Box::new(o1), bits:bits })
+                },
+                (TrieRec::Bin(l), TrieRec::Leaf(r)) => {
+                    let (e0, e1) = (Vec::new(), Vec::new());
+                    let (r0, r1) = Self::split_vec(r.kvs, bits.len, e0, e1);
+                    let (b0, b1) = Self::split_bits(&bits);
+                    let o0 = Self::join_rec(meta.clone(), None, *l.left, Self::leaf_or_empty(r0), b0);
+                    let o1 = Self::join_rec(meta.clone(), None, *l.right, Self::leaf_or_empty(r1), b1);
+                    TrieRec::Bin(TrieBin{ left:Box::new(o0), right:Box::new(o1), bits:bits })
+                },
+                (TrieRec::Bin(l), TrieRec::Bin(r)) => {
+                    let test1 = l.bits == bits;
+                    let test2 = l.bits == r.bits;
+                    if !(test1 && test2) {
+                        panic!("\nInternal error: {:?} {:?} -- bits:{:?} l.bits:{:?} r.bits:{:?}!!!\n", 
+                               test1, test2, bits, l.bits, r.bits);
+                    };
+                    let (b0, b1) = Self::split_bits(&bits);
+                    let o0 = Self::join_rec(meta.clone(), None, *l.left,  *r.left, b0);
+                    let o1 = Self::join_rec(meta.clone(), None, *l.right, *r.right, b1);
+                    TrieRec::Bin(TrieBin{ left:Box::new(o0), right:Box::new(o1), bits:bits })
+                }
+            }}
+        }   
+    }
+
+/*
     fn join_rec (meta:TrieMeta, lt: TrieRec<K,V>, rt: TrieRec<K,V>, bits:Bits, n:Name) -> TrieRec<K,V> {
         match (lt, rt) {
-            (TrieRec::Empty, rt) => rt,
-            (lt, TrieRec::Empty) => lt,
-            (TrieRec::Leaf(mut l), TrieRec::Leaf(r)) => {
-                if l.map.len() == 0 { 
+            (TrieRec::Empty,   TrieRec::Empty)   => TrieRec::Empty,
+            (TrieRec::Empty,   TrieRec::Leaf(r)) => TrieRec::Leaf(r),
+            (TrieRec::Leaf(l), TrieRec::Empty  ) => TrieRec::Leaf(l),
+            (TrieRec::Leaf(l), TrieRec::Leaf(r)) => {
+                if l.kvs.len() == 0 { 
                     TrieRec::Leaf(r)
-                } else if r.map.len() == 0 {
+                } else if r.kvs.len() == 0 {
                     TrieRec::Leaf(l)
-                } else if l.map.len() + r.map.len() < meta.gauge {
+                } else if l.kvs.len() + r.kvs.len() < meta.gauge {
                     // Sub-Case: the leaves, when combined, are smaller than the gauge.
-                    for (k,(k_hash,v)) in r.map.into_iter() { 
-                        l.map.insert(k,(k_hash,v));
+                    let mut vec = (*l.kvs).clone();
+                    for &(ref k, ref k_hash, ref v) in r.kvs.iter() { 
+                        vec.push((k.clone(),k_hash.clone(),v.clone()));
                     }
-                    TrieRec::Leaf(l)
+                    Self::leaf_or_empty(vec)
                 } else {
                     // Sub-Case: the leaves are large enough to justify not being combined.
-                    let (e0, e1) = (HashMap::new(), HashMap::new());
-                    let (l0, l1) = Self::split_map(l.map, bits.len, e0, e1);
-                    let (r0, r1) = Self::split_map(r.map, bits.len, l0, l1);
+                    let (e0, e1) = (Vec::new(), Vec::new());
+                    let (l0, l1) = Self::split_vec(l.kvs, bits.len, e0, e1);
+                    let (r0, r1) = Self::split_vec(r.kvs, bits.len, l0, l1);
                     let (n1, n2) = name_fork(n.clone());
-                    let t0 = cell(n1, TrieRec::Leaf(TrieLeaf{map:r0}));
-                    let t1 = cell(n2, TrieRec::Leaf(TrieLeaf{map:r1}));
+                    let t0 = cell(n1, TrieRec::Leaf(TrieLeaf{kvs:Rc::new(r0)}));
+                    let t1 = cell(n2, TrieRec::Leaf(TrieLeaf{kvs:Rc::new(r1)}));
                     TrieRec::Bin(TrieBin{left:t0, right:t1, bits:bits, name:n})
                 }
             },
-            (TrieRec::Leaf(l), TrieRec::Bin(r)) => {
-                let (e0, e1) = (HashMap::new(), HashMap::new());
-                let (l0, l1) = Self::split_map(l.map, bits.len, e0, e1);
+            (TrieRec::Empty, TrieRec::Bin(r)) => {
+                //let (e0, e1) = (Vec::new(), Vec::new());
+                //let (l0, l1) = Self::split_vec(l.kvs, bits.len, e0, e1);
                 let (b0, b1) = Self::split_bits(&bits);
                 let (n0, n1) = name_fork(n.clone());
                 let (m0, m1) = name_fork(r.name.clone());
-                let o0 = eager!(n0 =>> Self::join_rec, m:meta.clone(), l:TrieRec::Leaf(TrieLeaf{map:l0}), r:get!(r.left),  b:b0, n:m0);
-                let o1 = eager!(n1 =>> Self::join_rec, m:meta.clone(), l:TrieRec::Leaf(TrieLeaf{map:l1}), r:get!(r.right), b:b1, n:m1);
+                let o0 = eager!(n0 =>> Self::join_rec, m:meta.clone(), l:TrieRec::Empty, r:get!(r.left),  b:b0, n:m0);
+                let o1 = eager!(n1 =>> Self::join_rec, m:meta.clone(), l:TrieRec::Empty, r:get!(r.right), b:b1, n:m1);
                 TrieRec::Bin(TrieBin{ left:o0.0, right:o1.0, name:n, bits:bits })
             },
-            (TrieRec::Bin(l), TrieRec::Leaf(r)) => {
-                let (e0, e1) = (HashMap::new(), HashMap::new());
-                let (r0, r1) = Self::split_map(r.map, bits.len, e0, e1);
+            (TrieRec::Leaf(l), TrieRec::Bin(r)) => {
+                let (e0, e1) = (Vec::new(), Vec::new());
+                let (l0, l1) = Self::split_vec(l.kvs, bits.len, e0, e1);
+                let (b0, b1) = Self::split_bits(&bits);
+                let (n0, n1) = name_fork(n.clone());
+                let (m0, m1) = name_fork(r.name.clone());
+                let o0 = eager!(n0 =>> Self::join_rec, m:meta.clone(), l:Self::leaf_or_empty(l0), r:get!(r.left),  b:b0, n:m0);
+                let o1 = eager!(n1 =>> Self::join_rec, m:meta.clone(), l:Self::leaf_or_empty(l1), r:get!(r.right), b:b1, n:m1);
+                TrieRec::Bin(TrieBin{ left:o0.0, right:o1.0, name:n, bits:bits })
+            },
+            (TrieRec::Bin(l), TrieRec::Empty) => {
                 let (b0, b1) = Self::split_bits(&bits);
                 let (n0, n1) = name_fork(n.clone());
                 let (m0, m1) = name_fork(l.name.clone());
-                let o0 = eager!(n0 =>> Self::join_rec, m:meta.clone(), l:get!(l.left),  r:TrieRec::Leaf(TrieLeaf{map:r0}), b:b0, n:m0);
-                let o1 = eager!(n1 =>> Self::join_rec, m:meta.clone(), l:get!(l.right), r:TrieRec::Leaf(TrieLeaf{map:r1}), b:b1, n:m1);
+                let o0 = eager!(n0 =>> Self::join_rec, m:meta.clone(), l:get!(l.left),  r:TrieRec::Empty, b:b0, n:m0);
+                let o1 = eager!(n1 =>> Self::join_rec, m:meta.clone(), l:get!(l.right), r:TrieRec::Empty, b:b1, n:m1);
+                TrieRec::Bin(TrieBin{ left:o0.0, right:o1.0, name:n, bits:bits })
+            },
+            (TrieRec::Bin(l), TrieRec::Leaf(r)) => {
+                let (e0, e1) = (Vec::new(), Vec::new());
+                let (r0, r1) = Self::split_vec(r.kvs, bits.len, e0, e1);
+                let (b0, b1) = Self::split_bits(&bits);
+                let (n0, n1) = name_fork(n.clone());
+                let (m0, m1) = name_fork(l.name.clone());
+                let o0 = eager!(n0 =>> Self::join_rec, m:meta.clone(), l:get!(l.left),  r:Self::leaf_or_empty(r0), b:b0, n:m0);
+                let o1 = eager!(n1 =>> Self::join_rec, m:meta.clone(), l:get!(l.right), r:Self::leaf_or_empty(r1), b:b1, n:m1);
                 TrieRec::Bin(TrieBin{ left:o0.0, right:o1.0, name:n, bits:bits })
             },
             (TrieRec::Bin(l), TrieRec::Bin(r)) => {
-                assert!(l.bits == bits);
-                assert!(l.bits == r.bits);
+                let test1 = l.bits == bits;
+                let test2 = l.bits == r.bits;
+                if !(test1 && test2) {
+                    panic!("\nInternal error: {:?} {:?} -- bits:{:?} l.bits:{:?} r.bits:{:?}!!!\n", test1, test2, bits, l.bits, r.bits);
+                };
                 let (n1, n2) = name_fork(n.clone());
                 let (b0, b1) = Self::split_bits(&bits);
                 let o0 = eager!(n1 =>> Self::join_rec, m:meta.clone(), l:get!(l.left),  r:get!(r.left), b:b0, n:l.name);
@@ -232,23 +552,32 @@ impl<K:'static+Hash+Eq+Clone+Debug,
                 TrieRec::Bin(TrieBin{ left:o0.0, right:o1.0, name:n, bits:bits })
             }
         }
-    }               
+    }
+     */
 }
 
+#[test] pub fn test_join_10_1   () { test_join(10,1) }
+#[test] pub fn test_join_100_1  () { test_join(100,1) }
+#[test] pub fn test_join_1000_1 () { test_join(1000,1) }
 
-#[test]
-pub fn test_join () {
-    fn at_leaf(v:&Vec<usize>) -> Trie<usize,()> {
-        let mut hm = HashMap::new();
-        for x in v { 
-            let x_hash = my_hash(&x);
-            hm.insert(*x,(x_hash,()));
-        }
-        Trie::from_hashmap(hm)
-    }    
-    fn at_bin(l:Trie<usize,()>,_lev:u32,n:Option<Name>,r:Trie<usize,()>) -> Trie<usize,()> {
-        Trie::join(l,r,n.unwrap())
-    }
+#[test] pub fn test_join_10_2   () { test_join(10,2) }
+#[test] pub fn test_join_100_2  () { test_join(100,2) }
+#[test] pub fn test_join_1000_2 () { test_join(1000,2) }
+
+#[test] pub fn test_join_10_3   () { test_join(10,3) }
+#[test] pub fn test_join_100_3  () { test_join(100,3) }
+#[test] pub fn test_join_1000_3 () { test_join(1000,3) }
+
+#[test] pub fn test_join_10_4   () { test_join(10,4) }
+#[test] pub fn test_join_100_4  () { test_join(100,4) }
+#[test] pub fn test_join_1000_4 () { test_join(1000,4) }
+
+#[test] pub fn test_join_10_5   () { test_join(10,5) }
+#[test] pub fn test_join_100_5  () { test_join(100,5) }
+#[test] pub fn test_join_1000_5 () { test_join(1000,5) }
+
+
+pub fn test_join (size:usize, gauge:usize) {
     use rand::{thread_rng,Rng};
     use adapton::engine::*;
     use archive_stack::*;
@@ -256,27 +585,52 @@ pub fn test_join () {
     use memo::*;
     use level_tree::*;
     use raz_meta::Count;
-    use std::rc::Rc;
+    use self::hammer_level_tree::LevTree;
 
-    let mut rng = thread_rng();
-    let mut elms : AStack<usize,_> = AStack::new();
-    let mut elmv : Vec<usize> = vec![];
-    for i in 0..1000 {
-        let elm = rng.gen::<usize>() % 100;
-        elmv.push(elm);
-        elms.push(elm);
-        if i % 1 == 0 {
-            elms.archive(Some(name_of_usize(i)), gen_branch_level(&mut rng));
+    manage::init_dcg();
+
+    let (elmv,lev_tree) = {
+        let mut rng = thread_rng();
+        let mut elms : AStack<usize,_> = AStack::new();
+        let mut elmv : Vec<usize> = vec![];
+        for i in 0..size {
+            let elm = rng.gen::<usize>() % size;
+            elmv.push(elm);
+            elms.push(elm);
+            if i % gauge == 0 {
+                elms.archive(Some(name_of_usize(i)), gen_branch_level(&mut rng));
+            }
         }
-    }
-    let tree: RazTree<_,Count> = RazTree::memo_from(&AtHead(elms));
-    //println!("{:?}\n", tree);
+        let raz_tree: RazTree<_,Count> = 
+            ns( name_of_str("tree_of_stack"), || 
+                RazTree::memo_from(&AtHead(elms) ) );
 
-    let trie = tree.fold_up_gauged(Rc::new(at_leaf),Rc::new(at_bin)).unwrap();
-    //println!("{:?}\n", trie);
+        let lev_tree: LevTree<_> = 
+            ns( name_of_str("lev_tree_of_raz_tree"), || 
+                LevTree::from_raz_tree(raz_tree) );
+
+        (elmv,lev_tree)
+    };
+
+    fn at_leaf(_:(), v:Vec<usize>) -> Trie<usize,()> {
+        Trie::<usize,()>::from_key_vec(v)
+    }    
+    fn at_namebin(_:(), _lev:u32,n:Option<Name>,l:Trie<usize,()>,r:Trie<usize,()>) -> Trie<usize,()> {
+        assert!(l.is_wf());
+        assert!(r.is_wf());
+        ns(n.clone().unwrap(), || Trie::join(n,l,r) )
+    }
+    fn at_art(_a:Art<Trie<usize,()>>, t:Trie<usize,()>) -> Trie<usize,()> {
+        t 
+    }
+    let trie = ns( name_of_str("trie_of_lev_tree"),
+                   || LevTree::fold_up_namebin( lev_tree,
+                                                (), at_leaf,
+                                                (), at_namebin, at_art ) );
+    println!("{:?}\n", trie);
 
     for i in elmv {
-        //println!("find {:?}", i);
+        println!("find {:?}", i);
         assert_eq!(trie.find(&i), Some(()));
     }
 }

--- a/src/trie1.rs
+++ b/src/trie1.rs
@@ -1,0 +1,636 @@
+//! Binary Hash Tries, for representing sets and finite maps.
+//!
+//! Suitable for the Archivist role in Adapton.
+//!
+// Matthew Hammer <Matthew.Hammer@Colorado.edu>
+
+//use std::rc::Rc;
+use std::fmt;
+use std::fmt::Debug;
+use std::hash::{Hash,Hasher};
+//use std::collections::HashMap;
+use std::collections::hash_map::DefaultHasher;
+use adapton::engine::*;
+use adapton::macros::*;
+
+pub mod hammer_level_tree {
+    use std::fmt::Debug;
+    use std::hash::{Hash};
+    use adapton::macros::*;
+    use adapton::engine::{Name,Art,cell,force,thunk,ArtIdChoice};
+    use raz::RazTree;
+    use raz_meta::Count;
+
+    #[derive(Clone,PartialEq,Eq,Debug,Hash)]
+    struct BinCons<X> {
+        level: u32,
+        recl:Box<Rec<X>>,
+        recr:Box<Rec<X>>
+    }
+    #[derive(Clone,PartialEq,Eq,Debug,Hash)]
+    struct NameCons<X> {
+        level:u32,
+        name:Name,
+        rec:Box<Rec<X>>,
+    }
+    #[derive(Clone,PartialEq,Eq,Debug,Hash)]
+    struct LeafCons<X> {
+        elms:Vec<X>,
+    }
+    #[derive(Clone,PartialEq,Eq,Debug,Hash)]
+    enum Rec<X> {
+        Leaf(LeafCons<X>),
+        Bin(BinCons<X>),
+        Name(NameCons<X>),
+        Art(Art<Rec<X>>),
+    }
+    #[derive(Clone,PartialEq,Eq,Debug,Hash)]
+    pub struct LevTree<X> {
+        rec:Rec<X>
+    }
+
+    impl<X:'static+Clone+PartialEq+Eq+Debug+Hash> 
+        LevTree<X> 
+    {
+        pub fn leaf(xs:Vec<X>) -> Self { 
+            LevTree{rec:Rec::Leaf(LeafCons{elms:xs})} 
+        }
+        pub fn bin(lev:u32, l:Self, r:Self) -> Self { 
+            LevTree{rec:Rec::Bin(BinCons{level:lev,recl:Box::new(l.rec),recr:Box::new(r.rec)})} 
+        }
+        pub fn name(lev:u32, n:Name, r:Self) -> Self {
+            LevTree{rec:Rec::Name(NameCons{level:lev,name:n, rec:Box::new(r.rec)}) }
+        }
+        fn art(a:Art<Rec<X>>) -> Self {
+            LevTree{rec:Rec::Art(a)}
+        }
+        pub fn fold_monoid<B:'static+Clone+PartialEq+Eq+Debug+Hash>
+            (t:LevTree<X>, z:X, b:B, bin:fn(B,X,X)->X, art:fn(Art<X>,X)->X) -> X {
+                fn m_leaf<B:Clone,X>(m:(B,fn(B,X,X)->X,X), elms:Vec<X>) -> X { 
+                    let mut x = m.2;
+                    for elm in elms { x=m.1(m.0.clone(), x, elm) };
+                    x
+                }
+                fn m_bin<B,X>(m:(B,fn(B,X,X)->X,X), _lev:u32, _n:Option<Name>, l:X, r:X) -> X { 
+                    m.1(m.0, l, r)
+                }
+                Self::fold_up_namebin::<(B,fn(B,X,X)->X,X),
+                                        (B,fn(B,X,X)->X,X),X>
+                    (t,
+                     (b.clone(),bin,z.clone()), m_leaf,
+                     (b,bin,z), m_bin, 
+                     art)
+            }
+
+        pub fn fold_up
+            <L:'static+Clone+PartialEq+Eq+Debug+Hash,
+             B:'static+Clone+PartialEq+Eq+Debug+Hash,
+             N:'static+Clone+PartialEq+Eq+Debug+Hash,
+             R:'static+Clone+PartialEq+Eq+Debug+Hash>
+            (t:LevTree<X>, 
+             l:L, leaf:fn(L,Vec<X>)->R, 
+             b:B, bin:fn(B,u32,R,R)->R,
+             n:N, name:fn(N,u32,Name,R)->R) -> R {
+                Self::fold_up_rec(t.rec, l, leaf, b, bin, n, name)
+            }
+        
+        fn fold_up_rec<L:'static+Clone+PartialEq+Eq+Debug+Hash,
+                       B:'static+Clone+PartialEq+Eq+Debug+Hash,
+                       N:'static+Clone+PartialEq+Eq+Debug+Hash,
+                       R:'static+Clone+PartialEq+Eq+Debug+Hash>
+            (t:Rec<X>, 
+             l:L, leaf:fn(L,Vec<X>)->R, 
+             b:B, bin:fn(B,u32,R,R)->R,
+             n:N, name:fn(N,u32,Name,R)->R) -> R {
+                match t {
+                    Rec::Art(a) => Self::fold_up_rec(get!(a), l, leaf, b, bin, n, name),
+                    Rec::Leaf(leafcons) => leaf(l, leafcons.elms),
+                    Rec::Bin(bincons)   => {
+                        let r1 = Self::fold_up_rec(*bincons.recl, l.clone(), leaf, b.clone(), bin, n.clone(), name);
+                        let r2 = Self::fold_up_rec(*bincons.recr, l.clone(), leaf, b.clone(), bin, n.clone(), name);
+                        bin(b, bincons.level, r1, r2)
+                    }
+                    Rec::Name(namecons) => {
+                        let r = Self::fold_up_rec(*namecons.rec, l, leaf, b, bin, n.clone(), name);
+                        name(n, namecons.level, namecons.name, r)
+                    }
+                }
+            }
+
+        pub fn fold_up_namebin
+            <L:'static+Clone+PartialEq+Eq+Debug+Hash,
+             B:'static+Clone+PartialEq+Eq+Debug+Hash,
+             R:'static+Clone+PartialEq+Eq+Debug+Hash>
+            (t:LevTree<X>, 
+             l:L, leaf:fn(L,Vec<X>)->R, 
+             b:B, namebin:fn(B,u32,Option<Name>,R,R)->R, 
+             art:fn(Art<R>,R)->R) -> R {
+                Self::fold_up_namebin_rec(t.rec, l, leaf, b, None, namebin, art)
+            }
+        
+        fn fold_up_namebin_rec
+            <L:'static+Clone+PartialEq+Eq+Debug+Hash,
+             B:'static+Clone+PartialEq+Eq+Debug+Hash,
+             R:'static+Clone+PartialEq+Eq+Debug+Hash>             
+            (t:Rec<X>,
+             l:L, leaf:fn(L,Vec<X>)->R,
+             b:B, n:Option<Name>,
+             namebin:fn(B,u32,Option<Name>,R,R)->R,
+             art:fn(Art<R>,R)->R) -> R {
+                match t {
+                    Rec::Art(a) => Self::fold_up_namebin_rec(get!(a), l, leaf, b, n, namebin, art),
+                    Rec::Leaf(leafcons) => leaf(l, leafcons.elms),
+                    Rec::Bin(bincons)   => {
+                        let r1 = Self::fold_up_namebin_rec(*bincons.recl, l.clone(), leaf, b.clone(), None, namebin, art);
+                        let r2 = Self::fold_up_namebin_rec(*bincons.recr, l.clone(), leaf, b.clone(), None, namebin, art);
+                        namebin(b, bincons.level, n, r1, r2)
+                    }
+                    Rec::Name(namecons) => {
+                        let (a,x) = eager!( 
+                            namecons.name.clone() =>> Self::fold_up_namebin_rec,
+                            t:*namecons.rec, 
+                            l:l, leaf:leaf,
+                            b:b, n:Some(namecons.name), namebin:namebin, art:art 
+                        );
+                        art(a,x)
+                    }
+                }
+            }
+        
+        pub fn from_raz_tree(t:RazTree<X,Count>) -> LevTree<X> {
+            fn at_leaf<X:'static+Clone+PartialEq+Eq+Debug+Hash>
+                (v:&Vec<X>) -> LevTree<X> {
+                    LevTree::leaf(v.clone())
+                }
+            fn at_bin<X:'static+Clone+PartialEq+Eq+Debug+Hash>
+                (l:LevTree<X>,lev:u32,n:Option<Name>,r:LevTree<X>) -> LevTree<X> {
+                    match n {
+                        None => LevTree::bin(lev,l,r),
+                        Some(n) => {
+                            let n_ = n.clone();
+                            let a = LevTree::art(cell(n_, LevTree::bin(lev, l, r).rec));
+                            LevTree::name(lev, n, a)
+                        }
+                    }
+                }
+            t.fold_up_gauged(Rc::new(at_leaf), Rc::new(at_bin)).unwrap()
+        }
+    }
+}
+
+fn my_hash<T>(obj: T) -> HashVal
+  where T: Hash
+{
+  let mut hasher = DefaultHasher::new();
+  obj.hash(&mut hasher);
+  HashVal(hasher.finish() as usize)
+}
+
+/// A hash value -- We define a custom Debug impl for this type.
+#[derive(Clone,Hash,Eq,PartialEq)]
+pub struct HashVal(usize);
+
+impl fmt::Debug for HashVal {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:b}", self.0 & 0b1111)
+    }
+}
+
+#[derive(PartialEq,Eq,Clone,Hash)]
+struct Bits {bits:u32, len:u32}
+
+impl fmt::Debug for Bits {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Bits{{bits:{:b}, len:{}}}", self.bits, self.len)
+    }
+}
+
+#[derive(PartialEq,Eq,Clone,Debug,Hash)]
+pub struct Trie
+    <K:'static+Hash+PartialEq+Eq+Clone+Debug,
+     V:'static+Hash+PartialEq+Eq+Clone+Debug>
+{
+    meta:TrieMeta,
+    rec:TrieRec<K,V>,
+}
+
+#[derive(PartialEq,Eq,Clone,Debug,Hash)]
+pub struct TrieMeta {
+    gauge:usize,
+}
+
+#[derive(PartialEq,Eq,Clone,Debug,Hash)]
+pub enum TrieRec<K:'static+Hash+PartialEq+Eq+Clone+Debug,
+             V:'static+Hash+PartialEq+Eq+Clone+Debug>
+{
+    Empty,
+    Leaf(TrieLeaf<K,V>),
+    Bin(TrieBin<K,V>),
+    Name(TrieName<K,V>),
+    Art(Art<TrieRec<K,V>>),
+}
+#[derive(PartialEq,Eq,Clone,Debug,Hash)]
+pub struct TrieLeaf<K:'static+Hash+PartialEq+Eq+Clone+Debug,
+                    V:'static+Hash+PartialEq+Eq+Clone+Debug> {
+    kvs:Rc<Vec<(K,HashVal,V)>>,
+}
+#[derive(Hash,PartialEq,Eq,Clone,Debug)]
+pub struct TrieBin<K:'static+Hash+PartialEq+Eq+Clone+Debug,
+                   V:'static+Hash+PartialEq+Eq+Clone+Debug> {
+    bits:   Bits,
+    left:   Box<TrieRec<K,V>>,
+    right:  Box<TrieRec<K,V>>,
+}
+#[derive(Hash,PartialEq,Eq,Clone,Debug)]
+pub struct TrieName<K:'static+Hash+PartialEq+Eq+Clone+Debug,
+                    V:'static+Hash+PartialEq+Eq+Clone+Debug> {
+    name:   Name,
+    rec:    Box<TrieRec<K,V>>,
+}
+
+impl<K:'static+Hash+PartialEq+Eq+Clone+Debug,
+     V:'static+Hash+PartialEq+Eq+Clone+Debug> Trie<K,V> {
+
+    pub fn find (&self, k:&K) -> Option<V> {
+        Self::find_hash(self, my_hash(k), k)
+    }
+
+    pub fn find_hash (t: &Trie<K,V>, h:HashVal, k:&K) -> Option<V> {
+        Self::find_rec(t, &t.rec, h.clone(), h, k)
+    }
+
+    fn find_rec (t: &Trie<K,V>, r:&TrieRec<K,V>, h:HashVal, h_rest:HashVal, k:&K) -> Option<V> {
+        match r {
+            &TrieRec::Art(ref a) => Self::find_rec(t, &get!(a), h, h_rest, k),
+            &TrieRec::Name(ref n) => Self::find_rec(t, &*n.rec, h, h_rest, k),
+            &TrieRec::Empty => None,
+            &TrieRec::Leaf(ref l) => {
+                let mut ans = None;
+                for &(ref k2,ref k2_hash,ref v) in l.kvs.iter() {
+                    if k2_hash == &h && k2 == k {
+                        ans = Some(v.clone())
+                    }
+                }
+                return ans
+            },
+            &TrieRec::Bin(ref b) => {
+                if h_rest.0 & 1 == 0 {
+                    Self::find_rec(t, &*b.left, h, HashVal(h_rest.0 >> 1), k)
+                } else { 
+                    Self::find_rec(t, &*b.right, h, HashVal(h_rest.0 >> 1), k)
+                }
+            }
+        }
+    }
+
+    fn split_vec (vec: Rc<Vec<(K,HashVal,V)>>,
+                  bits_len:u32,
+                  mut vec0:Vec<(K,HashVal,V)>, 
+                  mut vec1:Vec<(K,HashVal,V)>)
+                  -> (Vec<(K,HashVal,V)>, Vec<(K,HashVal,V)>)
+    {
+        //let mask : u64 = make_mask(bits_len as usize) as u64;
+        for &(ref k, ref k_hash, ref v) in vec.iter() {
+            //assert_eq!((mask & k_hash) >> 1, bits.bits as u64); // XXX/???
+            if 0 == (k_hash.0 & (1 << bits_len)) {
+                vec0.push((k.clone(),k_hash.clone(),v.clone()))
+            } else {
+                vec1.push((k.clone(),k_hash.clone(),v.clone()))
+            }
+        };
+        (vec0, vec1)
+    }
+
+    fn meta (gauge:usize) -> TrieMeta {
+        TrieMeta{gauge:gauge}
+    }
+
+    pub fn empty (gauge:usize) -> Self { 
+        Trie{meta:Self::meta(gauge), rec:TrieRec::Empty}
+    }
+
+    pub fn from_vec(vec_in:&Vec<(K,V)>) -> Self { 
+        let mut vec = Vec::new();
+        for &(ref k, ref v) in vec_in.iter() {
+            let k_hash = my_hash(k);
+            vec.push((k.clone(),k_hash,v.clone()));
+        };
+        Trie{meta:Self::meta(vec.len()), 
+             rec:TrieRec::Leaf(TrieLeaf{kvs:Rc::new(vec)})}
+    }
+
+    pub fn from_key_vec_ref(vec_in:&Vec<K>) -> Trie<K,()> { 
+        let mut vec = Vec::new();
+        for k in vec_in.iter() {
+            let k_hash = my_hash(k);
+            vec.push((k.clone(),k_hash,()));
+        };
+        Trie{meta:Self::meta(vec.len()), 
+             rec:TrieRec::Leaf(TrieLeaf{kvs:Rc::new(vec)})}
+    }
+
+    pub fn from_key_vec(vec_in:Vec<K>) -> Trie<K,()> { 
+        let mut vec = Vec::new();
+        for k in vec_in {
+            let k_hash = my_hash(&k);
+            vec.push((k,k_hash,()));
+        };
+        Trie{meta:Self::meta(vec.len()), 
+             rec:TrieRec::Leaf(TrieLeaf{kvs:Rc::new(vec)})}
+    }
+
+    pub fn join (n:Option<Name>, lt: Self, rt: Self) -> Self {
+        //assert_eq!(lt.gauge, rt.gauge); // ??? -- Or take the min? Or the max? Or the average?
+        let gauge = if lt.meta.gauge > rt.meta.gauge { lt.meta.gauge } else { rt.meta.gauge };
+        Trie{rec:Self::join_rec(TrieMeta{gauge:gauge}, n, lt.rec, rt.rec, Bits{len:0, bits:0}),..lt}
+    }
+
+    fn split_bits (bits:&Bits) -> (Bits, Bits) {
+        let lbits = Bits{len:bits.len+1, bits:/* zero ------ */ bits.bits };
+        let rbits = Bits{len:bits.len+1, bits:(1 << bits.len) | bits.bits };
+        (lbits, rbits)
+    }
+
+    // TODO-Soon: Opt: After splitting a vec, create leaves by first checking whether the vec is empty.
+
+    fn leaf_or_empty (kvs:Vec<(K,HashVal,V)>) -> TrieRec<K,V> {
+        if kvs.len() == 0 { TrieRec::Empty }
+        else { TrieRec::Leaf(TrieLeaf{kvs:Rc::new(kvs)}) }
+    }
+
+    fn is_wf_rec (t:&TrieRec<K,V>, bits:Bits) -> bool {
+        match *t {
+            TrieRec::Art(ref a) => Self::is_wf_rec(&get!(a), bits),
+            TrieRec::Name(ref n) => Self::is_wf_rec(&*n.rec, bits),
+            TrieRec::Empty => true,
+            TrieRec::Leaf(ref leaf) => {
+                // Check that all of the hash values match the given bit pattern of bits.
+                for &(_,ref hv, _) in leaf.kvs.iter() {
+                    for i in 0..bits.len {
+                        if ((bits.bits & (1 << i)) as usize) == (hv.0 & (1 << i)) { continue }
+                        else { return false }
+                    }
+                }
+                return true
+            }
+            // Check bit patterns match, and that recursive trees are well-formed.
+            TrieRec::Bin(ref b) => { 
+                let (b0, b1) = Self::split_bits(&bits);
+                let lwf = Self::is_wf_rec(&*b.left, b0);
+                let rwf = Self::is_wf_rec(&*b.right, b1);
+                b.bits == bits && lwf && rwf 
+            }
+        }
+    }
+
+    fn is_wf(self:&Self) -> bool {
+        Self::is_wf_rec(&self.rec, Bits{bits:0, len:0})
+    }
+
+    fn join_rec (meta:TrieMeta, n:Option<Name>, lt: TrieRec<K,V>, rt: TrieRec<K,V>, bits:Bits) -> TrieRec<K,V> {
+        match n {
+            Some(n) => {
+                let (a,_trie) = eager!(n.clone() =>> Self::join_rec, meta:meta, n:None, lt:lt, rt:rt, bits:bits);
+                TrieRec::Name(TrieName{name:n, rec:Box::new(TrieRec::Art(a))})
+            },
+            None => { match (lt, rt) {
+                (TrieRec::Empty,   TrieRec::Empty)   => TrieRec::Empty,
+                (TrieRec::Empty,   TrieRec::Leaf(r)) => TrieRec::Leaf(r),
+                (TrieRec::Leaf(l), TrieRec::Empty  ) => TrieRec::Leaf(l),
+
+                (TrieRec::Name(l), TrieRec::Name(r)) => { Self::join_rec (meta, Some(l.name), *l.rec, *r.rec, bits) },
+
+                (TrieRec::Name(n), rt) => { Self::join_rec (meta, Some(n.name), *n.rec, rt, bits) },
+                (lt, TrieRec::Name(n)) => { Self::join_rec (meta, Some(n.name), lt, *n.rec, bits) },
+                
+                (TrieRec::Art(a), rt) => { Self::join_rec (meta, n, get!(a), rt, bits) },
+                (lt, TrieRec::Art(a)) => { Self::join_rec (meta, n, lt, get!(a), bits) },
+
+                (TrieRec::Leaf(l), TrieRec::Leaf(r)) => {
+                    if l.kvs.len() == 0 { 
+                        TrieRec::Leaf(r)
+                    } else if r.kvs.len() == 0 {
+                        TrieRec::Leaf(l)
+                    } else if l.kvs.len() + r.kvs.len() < meta.gauge {
+                        // Sub-Case: the leaves, when combined, are smaller than the gauge.
+                        let mut vec = (*l.kvs).clone();
+                        for &(ref k, ref k_hash, ref v) in r.kvs.iter() { 
+                            vec.push((k.clone(),k_hash.clone(),v.clone()));
+                        }
+                        Self::leaf_or_empty(vec)
+                    } else {
+                        // Sub-Case: the leaves are large enough to justify not being combined.
+                        let (e0, e1) = (Vec::new(), Vec::new());
+                        let (l0, l1) = Self::split_vec(l.kvs, bits.len, e0, e1);
+                        let (r0, r1) = Self::split_vec(r.kvs, bits.len, l0, l1);
+                        let t0 = Box::new(TrieRec::Leaf(TrieLeaf{kvs:Rc::new(r0)}));
+                        let t1 = Box::new(TrieRec::Leaf(TrieLeaf{kvs:Rc::new(r1)}));
+                        TrieRec::Bin(TrieBin{left:t0, right:t1, bits:bits})
+                    }
+                },
+                (TrieRec::Empty, TrieRec::Bin(r)) => {
+                    let (b0, b1) = Self::split_bits(&bits);
+                    let o0 = Self::join_rec(meta.clone(), None, TrieRec::Empty, *r.left, b0);
+                    let o1 = Self::join_rec(meta.clone(), None, TrieRec::Empty, *r.right, b1);
+                    TrieRec::Bin(TrieBin{ left:Box::new(o0), right:Box::new(o1), bits:bits })
+                },
+                (TrieRec::Leaf(l), TrieRec::Bin(r)) => {
+                    let (e0, e1) = (Vec::new(), Vec::new());
+                    let (l0, l1) = Self::split_vec(l.kvs, bits.len, e0, e1);
+                    let (b0, b1) = Self::split_bits(&bits);
+                    let o0 = Self::join_rec(meta.clone(), None, Self::leaf_or_empty(l0), *r.left, b0);
+                    let o1 = Self::join_rec(meta.clone(), None, Self::leaf_or_empty(l1), *r.right, b1);
+                    TrieRec::Bin(TrieBin{ left:Box::new(o0), right:Box::new(o1), bits:bits })
+                },
+                (TrieRec::Bin(l), TrieRec::Empty) => {
+                    let (b0, b1) = Self::split_bits(&bits);
+                    let o0 = Self::join_rec(meta.clone(), None, *l.left, TrieRec::Empty, b0);
+                    let o1 = Self::join_rec(meta.clone(), None, *l.right, TrieRec::Empty, b1);
+                    TrieRec::Bin(TrieBin{ left:Box::new(o0), right:Box::new(o1), bits:bits })
+                },
+                (TrieRec::Bin(l), TrieRec::Leaf(r)) => {
+                    let (e0, e1) = (Vec::new(), Vec::new());
+                    let (r0, r1) = Self::split_vec(r.kvs, bits.len, e0, e1);
+                    let (b0, b1) = Self::split_bits(&bits);
+                    let o0 = Self::join_rec(meta.clone(), None, *l.left, Self::leaf_or_empty(r0), b0);
+                    let o1 = Self::join_rec(meta.clone(), None, *l.right, Self::leaf_or_empty(r1), b1);
+                    TrieRec::Bin(TrieBin{ left:Box::new(o0), right:Box::new(o1), bits:bits })
+                },
+                (TrieRec::Bin(l), TrieRec::Bin(r)) => {
+                    let test1 = l.bits == bits;
+                    let test2 = l.bits == r.bits;
+                    if !(test1 && test2) {
+                        panic!("\nInternal error: {:?} {:?} -- bits:{:?} l.bits:{:?} r.bits:{:?}!!!\n", 
+                               test1, test2, bits, l.bits, r.bits);
+                    };
+                    let (b0, b1) = Self::split_bits(&bits);
+                    let o0 = Self::join_rec(meta.clone(), None, *l.left,  *r.left, b0);
+                    let o1 = Self::join_rec(meta.clone(), None, *l.right, *r.right, b1);
+                    TrieRec::Bin(TrieBin{ left:Box::new(o0), right:Box::new(o1), bits:bits })
+                }
+            }}
+        }   
+    }
+
+/*
+    fn join_rec (meta:TrieMeta, lt: TrieRec<K,V>, rt: TrieRec<K,V>, bits:Bits, n:Name) -> TrieRec<K,V> {
+        match (lt, rt) {
+            (TrieRec::Empty,   TrieRec::Empty)   => TrieRec::Empty,
+            (TrieRec::Empty,   TrieRec::Leaf(r)) => TrieRec::Leaf(r),
+            (TrieRec::Leaf(l), TrieRec::Empty  ) => TrieRec::Leaf(l),
+            (TrieRec::Leaf(l), TrieRec::Leaf(r)) => {
+                if l.kvs.len() == 0 { 
+                    TrieRec::Leaf(r)
+                } else if r.kvs.len() == 0 {
+                    TrieRec::Leaf(l)
+                } else if l.kvs.len() + r.kvs.len() < meta.gauge {
+                    // Sub-Case: the leaves, when combined, are smaller than the gauge.
+                    let mut vec = (*l.kvs).clone();
+                    for &(ref k, ref k_hash, ref v) in r.kvs.iter() { 
+                        vec.push((k.clone(),k_hash.clone(),v.clone()));
+                    }
+                    Self::leaf_or_empty(vec)
+                } else {
+                    // Sub-Case: the leaves are large enough to justify not being combined.
+                    let (e0, e1) = (Vec::new(), Vec::new());
+                    let (l0, l1) = Self::split_vec(l.kvs, bits.len, e0, e1);
+                    let (r0, r1) = Self::split_vec(r.kvs, bits.len, l0, l1);
+                    let (n1, n2) = name_fork(n.clone());
+                    let t0 = cell(n1, TrieRec::Leaf(TrieLeaf{kvs:Rc::new(r0)}));
+                    let t1 = cell(n2, TrieRec::Leaf(TrieLeaf{kvs:Rc::new(r1)}));
+                    TrieRec::Bin(TrieBin{left:t0, right:t1, bits:bits, name:n})
+                }
+            },
+            (TrieRec::Empty, TrieRec::Bin(r)) => {
+                //let (e0, e1) = (Vec::new(), Vec::new());
+                //let (l0, l1) = Self::split_vec(l.kvs, bits.len, e0, e1);
+                let (b0, b1) = Self::split_bits(&bits);
+                let (n0, n1) = name_fork(n.clone());
+                let (m0, m1) = name_fork(r.name.clone());
+                let o0 = eager!(n0 =>> Self::join_rec, m:meta.clone(), l:TrieRec::Empty, r:get!(r.left),  b:b0, n:m0);
+                let o1 = eager!(n1 =>> Self::join_rec, m:meta.clone(), l:TrieRec::Empty, r:get!(r.right), b:b1, n:m1);
+                TrieRec::Bin(TrieBin{ left:o0.0, right:o1.0, name:n, bits:bits })
+            },
+            (TrieRec::Leaf(l), TrieRec::Bin(r)) => {
+                let (e0, e1) = (Vec::new(), Vec::new());
+                let (l0, l1) = Self::split_vec(l.kvs, bits.len, e0, e1);
+                let (b0, b1) = Self::split_bits(&bits);
+                let (n0, n1) = name_fork(n.clone());
+                let (m0, m1) = name_fork(r.name.clone());
+                let o0 = eager!(n0 =>> Self::join_rec, m:meta.clone(), l:Self::leaf_or_empty(l0), r:get!(r.left),  b:b0, n:m0);
+                let o1 = eager!(n1 =>> Self::join_rec, m:meta.clone(), l:Self::leaf_or_empty(l1), r:get!(r.right), b:b1, n:m1);
+                TrieRec::Bin(TrieBin{ left:o0.0, right:o1.0, name:n, bits:bits })
+            },
+            (TrieRec::Bin(l), TrieRec::Empty) => {
+                let (b0, b1) = Self::split_bits(&bits);
+                let (n0, n1) = name_fork(n.clone());
+                let (m0, m1) = name_fork(l.name.clone());
+                let o0 = eager!(n0 =>> Self::join_rec, m:meta.clone(), l:get!(l.left),  r:TrieRec::Empty, b:b0, n:m0);
+                let o1 = eager!(n1 =>> Self::join_rec, m:meta.clone(), l:get!(l.right), r:TrieRec::Empty, b:b1, n:m1);
+                TrieRec::Bin(TrieBin{ left:o0.0, right:o1.0, name:n, bits:bits })
+            },
+            (TrieRec::Bin(l), TrieRec::Leaf(r)) => {
+                let (e0, e1) = (Vec::new(), Vec::new());
+                let (r0, r1) = Self::split_vec(r.kvs, bits.len, e0, e1);
+                let (b0, b1) = Self::split_bits(&bits);
+                let (n0, n1) = name_fork(n.clone());
+                let (m0, m1) = name_fork(l.name.clone());
+                let o0 = eager!(n0 =>> Self::join_rec, m:meta.clone(), l:get!(l.left),  r:Self::leaf_or_empty(r0), b:b0, n:m0);
+                let o1 = eager!(n1 =>> Self::join_rec, m:meta.clone(), l:get!(l.right), r:Self::leaf_or_empty(r1), b:b1, n:m1);
+                TrieRec::Bin(TrieBin{ left:o0.0, right:o1.0, name:n, bits:bits })
+            },
+            (TrieRec::Bin(l), TrieRec::Bin(r)) => {
+                let test1 = l.bits == bits;
+                let test2 = l.bits == r.bits;
+                if !(test1 && test2) {
+                    panic!("\nInternal error: {:?} {:?} -- bits:{:?} l.bits:{:?} r.bits:{:?}!!!\n", test1, test2, bits, l.bits, r.bits);
+                };
+                let (n1, n2) = name_fork(n.clone());
+                let (b0, b1) = Self::split_bits(&bits);
+                let o0 = eager!(n1 =>> Self::join_rec, m:meta.clone(), l:get!(l.left),  r:get!(r.left), b:b0, n:l.name);
+                let o1 = eager!(n2 =>> Self::join_rec, m:meta.clone(), l:get!(l.right), r:get!(r.right), b:b1, n:r.name);
+                TrieRec::Bin(TrieBin{ left:o0.0, right:o1.0, name:n, bits:bits })
+            }
+        }
+    }
+     */
+}
+
+#[test] pub fn test_join_10_1   () { test_join(10,1) }
+//#[test] pub fn test_join_100_1  () { test_join(100,1) }
+//#[test] pub fn test_join_1000_1 () { test_join(1000,1) }
+
+#[test] pub fn test_join_10_2   () { test_join(10,2) }
+//#[test] pub fn test_join_100_2  () { test_join(100,2) }
+//#[test] pub fn test_join_1000_2 () { test_join(1000,2) }
+
+#[test] pub fn test_join_10_3   () { test_join(10,3) }
+//#[test] pub fn test_join_100_3  () { test_join(100,3) }
+//#[test] pub fn test_join_1000_3 () { test_join(1000,3) }
+
+#[test] pub fn test_join_10_4   () { test_join(10,4) }
+//#[test] pub fn test_join_100_4  () { test_join(100,4) }
+//#[test] pub fn test_join_1000_4 () { test_join(1000,4) }
+
+#[test] pub fn test_join_10_5   () { test_join(10,5) }
+//#[test] pub fn test_join_100_5  () { test_join(100,5) }
+//#[test] pub fn test_join_1000_5 () { test_join(1000,5) }
+
+
+pub fn test_join (size:usize, gauge:usize) {
+    use rand::{thread_rng,Rng};
+    use adapton::engine::*;
+    use archive_stack::*;
+    use raz::*;
+    use memo::*;
+    use level_tree::*;
+    use raz_meta::Count;
+    use self::hammer_level_tree::LevTree;
+
+    manage::init_dcg();
+
+    let (elmv,lev_tree) = {
+        let mut rng = thread_rng();
+        let mut elms : AStack<usize,_> = AStack::new();
+        let mut elmv : Vec<usize> = vec![];
+        for i in 0..size {
+            let elm = rng.gen::<usize>() % size;
+            elmv.push(elm);
+            elms.push(elm);
+            if i % gauge == 0 {
+                elms.archive(Some(name_of_usize(i)), gen_branch_level(&mut rng));
+            }
+        }
+        let raz_tree: RazTree<_,Count> = 
+            ns( name_of_str("tree_of_stack"), || 
+                RazTree::memo_from(&AtHead(elms) ) );
+
+        let lev_tree: LevTree<_> = 
+            ns( name_of_str("lev_tree_of_raz_tree"), || 
+                LevTree::from_raz_tree(raz_tree) );
+
+        (elmv,lev_tree)
+    };
+
+    fn at_leaf(_:(), v:Vec<usize>) -> Trie<usize,()> {
+        Trie::<usize,()>::from_key_vec(v)
+    }    
+    fn at_namebin(_:(), _lev:u32,n:Option<Name>,l:Trie<usize,()>,r:Trie<usize,()>) -> Trie<usize,()> {
+        assert!(l.is_wf());
+        assert!(r.is_wf());
+        ns(n.clone().unwrap(), || Trie::join(n,l,r) )
+    }
+    fn at_art(_a:Art<Trie<usize,()>>, t:Trie<usize,()>) -> Trie<usize,()> {
+        t 
+    }
+    let trie = ns( name_of_str("trie_of_lev_tree"),
+                   || LevTree::fold_up_namebin( lev_tree,
+                                                (), at_leaf,
+                                                (), at_namebin, at_art ) );
+    println!("{:?}\n", trie);
+
+    for i in elmv {
+        println!("find {:?}", i);
+        assert_eq!(trie.find(&i), Some(()));
+    }
+}

--- a/src/trie2.rs
+++ b/src/trie2.rs
@@ -226,8 +226,6 @@ pub enum TrieRec<K:'static+Hash+PartialEq+Eq+Clone+Debug,
     Empty,
     Leaf(TrieLeaf<K,V>),
     Bin(TrieBin<K,V>),
-    Name(TrieName<K,V>),
-    Art(Art<TrieRec<K,V>>),
 }
 #[derive(PartialEq,Eq,Clone,Debug,Hash)]
 pub struct TrieLeaf<K:'static+Hash+PartialEq+Eq+Clone+Debug,
@@ -237,15 +235,10 @@ pub struct TrieLeaf<K:'static+Hash+PartialEq+Eq+Clone+Debug,
 #[derive(Hash,PartialEq,Eq,Clone,Debug)]
 pub struct TrieBin<K:'static+Hash+PartialEq+Eq+Clone+Debug,
                    V:'static+Hash+PartialEq+Eq+Clone+Debug> {
-    bits:   Bits,
-    left:   Box<TrieRec<K,V>>,
-    right:  Box<TrieRec<K,V>>,
-}
-#[derive(Hash,PartialEq,Eq,Clone,Debug)]
-pub struct TrieName<K:'static+Hash+PartialEq+Eq+Clone+Debug,
-                    V:'static+Hash+PartialEq+Eq+Clone+Debug> {
     name:   Name,
-    rec:    Box<TrieRec<K,V>>,
+    bits:   Bits,
+    left:   Art<TrieRec<K,V>>,
+    right:  Art<TrieRec<K,V>>,
 }
 
 impl<K:'static+Hash+PartialEq+Eq+Clone+Debug,
@@ -261,8 +254,6 @@ impl<K:'static+Hash+PartialEq+Eq+Clone+Debug,
 
     fn find_rec (t: &Trie<K,V>, r:&TrieRec<K,V>, h:HashVal, h_rest:HashVal, k:&K) -> Option<V> {
         match r {
-            &TrieRec::Art(ref a) => Self::find_rec(t, &get!(a), h, h_rest, k),
-            &TrieRec::Name(ref n) => Self::find_rec(t, &*n.rec, h, h_rest, k),
             &TrieRec::Empty => None,
             &TrieRec::Leaf(ref l) => {
                 let mut ans = None;
@@ -275,9 +266,9 @@ impl<K:'static+Hash+PartialEq+Eq+Clone+Debug,
             },
             &TrieRec::Bin(ref b) => {
                 if h_rest.0 & 1 == 0 {
-                    Self::find_rec(t, &*b.left, h, HashVal(h_rest.0 >> 1), k)
+                    Self::find_rec(t, &get!(b.left), h, HashVal(h_rest.0 >> 1), k)
                 } else { 
-                    Self::find_rec(t, &*b.right, h, HashVal(h_rest.0 >> 1), k)
+                    Self::find_rec(t, &get!(b.right), h, HashVal(h_rest.0 >> 1), k)
                 }
             }
         }
@@ -339,10 +330,10 @@ impl<K:'static+Hash+PartialEq+Eq+Clone+Debug,
              rec:TrieRec::Leaf(TrieLeaf{kvs:Rc::new(vec)})}
     }
 
-    pub fn join (n:Option<Name>, lt: Self, rt: Self) -> Self {
+    pub fn join (n:Name, lt: Self, rt: Self) -> Self {
         //assert_eq!(lt.gauge, rt.gauge); // ??? -- Or take the min? Or the max? Or the average?
         let gauge = if lt.meta.gauge > rt.meta.gauge { lt.meta.gauge } else { rt.meta.gauge };
-        Trie{rec:Self::join_rec(TrieMeta{gauge:gauge}, n, lt.rec, rt.rec, Bits{len:0, bits:0}),..lt}
+        Trie{rec:Self::join_rec(TrieMeta{gauge:gauge}, lt.rec, rt.rec, Bits{len:0, bits:0}, n),..lt}
     }
 
     fn split_bits (bits:&Bits) -> (Bits, Bits) {
@@ -360,8 +351,6 @@ impl<K:'static+Hash+PartialEq+Eq+Clone+Debug,
 
     fn is_wf_rec (t:&TrieRec<K,V>, bits:Bits) -> bool {
         match *t {
-            TrieRec::Art(ref a) => Self::is_wf_rec(&get!(a), bits),
-            TrieRec::Name(ref n) => Self::is_wf_rec(&*n.rec, bits),
             TrieRec::Empty => true,
             TrieRec::Leaf(ref leaf) => {
                 // Check that all of the hash values match the given bit pattern of bits.
@@ -376,8 +365,8 @@ impl<K:'static+Hash+PartialEq+Eq+Clone+Debug,
             // Check bit patterns match, and that recursive trees are well-formed.
             TrieRec::Bin(ref b) => { 
                 let (b0, b1) = Self::split_bits(&bits);
-                let lwf = Self::is_wf_rec(&*b.left, b0);
-                let rwf = Self::is_wf_rec(&*b.right, b1);
+                let lwf = Self::is_wf_rec(&get!(b.left), b0);
+                let rwf = Self::is_wf_rec(&get!(b.right), b1);
                 b.bits == bits && lwf && rwf 
             }
         }
@@ -387,90 +376,6 @@ impl<K:'static+Hash+PartialEq+Eq+Clone+Debug,
         Self::is_wf_rec(&self.rec, Bits{bits:0, len:0})
     }
 
-    fn join_rec (meta:TrieMeta, n:Option<Name>, lt: TrieRec<K,V>, rt: TrieRec<K,V>, bits:Bits) -> TrieRec<K,V> {
-        match n {
-            Some(n) => {
-                let (a,_trie) = eager!(n.clone() =>> Self::join_rec, meta:meta, n:None, lt:lt, rt:rt, bits:bits);
-                TrieRec::Name(TrieName{name:n, rec:Box::new(TrieRec::Art(a))})
-            },
-            None => { match (lt, rt) {
-                (TrieRec::Empty,   TrieRec::Empty)   => TrieRec::Empty,
-                (TrieRec::Empty,   TrieRec::Leaf(r)) => TrieRec::Leaf(r),
-                (TrieRec::Leaf(l), TrieRec::Empty  ) => TrieRec::Leaf(l),
-
-                (TrieRec::Name(n), rt) => { Self::join_rec (meta, Some(n.name), *n.rec, rt, bits) },
-                (lt, TrieRec::Name(n)) => { Self::join_rec (meta, None,         lt, *n.rec, bits) },
-                
-                (TrieRec::Art(a), rt) => { Self::join_rec (meta, n, get!(a), rt, bits) },
-                (lt, TrieRec::Art(a)) => { Self::join_rec (meta, n, lt, get!(a), bits) },
-
-                (TrieRec::Leaf(l), TrieRec::Leaf(r)) => {
-                    if l.kvs.len() == 0 { 
-                        TrieRec::Leaf(r)
-                    } else if r.kvs.len() == 0 {
-                        TrieRec::Leaf(l)
-                    } else if l.kvs.len() + r.kvs.len() < meta.gauge {
-                        // Sub-Case: the leaves, when combined, are smaller than the gauge.
-                        let mut vec = (*l.kvs).clone();
-                        for &(ref k, ref k_hash, ref v) in r.kvs.iter() { 
-                            vec.push((k.clone(),k_hash.clone(),v.clone()));
-                        }
-                        Self::leaf_or_empty(vec)
-                    } else {
-                        // Sub-Case: the leaves are large enough to justify not being combined.
-                        let (e0, e1) = (Vec::new(), Vec::new());
-                        let (l0, l1) = Self::split_vec(l.kvs, bits.len, e0, e1);
-                        let (r0, r1) = Self::split_vec(r.kvs, bits.len, l0, l1);
-                        let t0 = Box::new(TrieRec::Leaf(TrieLeaf{kvs:Rc::new(r0)}));
-                        let t1 = Box::new(TrieRec::Leaf(TrieLeaf{kvs:Rc::new(r1)}));
-                        TrieRec::Bin(TrieBin{left:t0, right:t1, bits:bits})
-                    }
-                },
-                (TrieRec::Empty, TrieRec::Bin(r)) => {
-                    let (b0, b1) = Self::split_bits(&bits);
-                    let o0 = Self::join_rec(meta.clone(), None, TrieRec::Empty, *r.left, b0);
-                    let o1 = Self::join_rec(meta.clone(), None, TrieRec::Empty, *r.right, b1);
-                    TrieRec::Bin(TrieBin{ left:Box::new(o0), right:Box::new(o1), bits:bits })
-                },
-                (TrieRec::Leaf(l), TrieRec::Bin(r)) => {
-                    let (e0, e1) = (Vec::new(), Vec::new());
-                    let (l0, l1) = Self::split_vec(l.kvs, bits.len, e0, e1);
-                    let (b0, b1) = Self::split_bits(&bits);
-                    let o0 = Self::join_rec(meta.clone(), None, Self::leaf_or_empty(l0), *r.left, b0);
-                    let o1 = Self::join_rec(meta.clone(), None, Self::leaf_or_empty(l1), *r.right, b1);
-                    TrieRec::Bin(TrieBin{ left:Box::new(o0), right:Box::new(o1), bits:bits })
-                },
-                (TrieRec::Bin(l), TrieRec::Empty) => {
-                    let (b0, b1) = Self::split_bits(&bits);
-                    let o0 = Self::join_rec(meta.clone(), None, *l.left, TrieRec::Empty, b0);
-                    let o1 = Self::join_rec(meta.clone(), None, *l.right, TrieRec::Empty, b1);
-                    TrieRec::Bin(TrieBin{ left:Box::new(o0), right:Box::new(o1), bits:bits })
-                },
-                (TrieRec::Bin(l), TrieRec::Leaf(r)) => {
-                    let (e0, e1) = (Vec::new(), Vec::new());
-                    let (r0, r1) = Self::split_vec(r.kvs, bits.len, e0, e1);
-                    let (b0, b1) = Self::split_bits(&bits);
-                    let o0 = Self::join_rec(meta.clone(), None, *l.left, Self::leaf_or_empty(r0), b0);
-                    let o1 = Self::join_rec(meta.clone(), None, *l.right, Self::leaf_or_empty(r1), b1);
-                    TrieRec::Bin(TrieBin{ left:Box::new(o0), right:Box::new(o1), bits:bits })
-                },
-                (TrieRec::Bin(l), TrieRec::Bin(r)) => {
-                    let test1 = l.bits == bits;
-                    let test2 = l.bits == r.bits;
-                    if !(test1 && test2) {
-                        panic!("\nInternal error: {:?} {:?} -- bits:{:?} l.bits:{:?} r.bits:{:?}!!!\n", 
-                               test1, test2, bits, l.bits, r.bits);
-                    };
-                    let (b0, b1) = Self::split_bits(&bits);
-                    let o0 = Self::join_rec(meta.clone(), None, *l.left,  *r.left, b0);
-                    let o1 = Self::join_rec(meta.clone(), None, *l.right, *r.right, b1);
-                    TrieRec::Bin(TrieBin{ left:Box::new(o0), right:Box::new(o1), bits:bits })
-                }
-            }}
-        }   
-    }
-
-/*
     fn join_rec (meta:TrieMeta, lt: TrieRec<K,V>, rt: TrieRec<K,V>, bits:Bits, n:Name) -> TrieRec<K,V> {
         match (lt, rt) {
             (TrieRec::Empty,   TrieRec::Empty)   => TrieRec::Empty,
@@ -551,7 +456,6 @@ impl<K:'static+Hash+PartialEq+Eq+Clone+Debug,
             }
         }
     }
-     */
 }
 
 #[test] pub fn test_join_10_1   () { test_join(10,1) }
@@ -616,7 +520,7 @@ pub fn test_join (size:usize, gauge:usize) {
     fn at_namebin(_:(), _lev:u32,n:Option<Name>,l:Trie<usize,()>,r:Trie<usize,()>) -> Trie<usize,()> {
         assert!(l.is_wf());
         assert!(r.is_wf());
-        ns(n.clone().unwrap(), || Trie::join(n,l,r) )
+        ns(n.clone().unwrap(), || Trie::join(n.unwrap(),l,r) )
     }
     fn at_art(_a:Art<Trie<usize,()>>, t:Trie<usize,()>) -> Trie<usize,()> {
         t 

--- a/src/trie2.rs
+++ b/src/trie2.rs
@@ -238,6 +238,20 @@ impl<K:'static+Hash+PartialEq+Eq+Clone+Debug,
 }
 
 
+// #[test]
+// fn test_clone() {
+//     use std::collections::hash_map::HashMap;
+//     let mut hm : HashMap<usize, usize> = HashMap::new();
+//     hm.insert(1, 2);
+//     hm.insert(3, 4);
+//     let mut v : Vec<usize> = vec![];
+//     for (k,v) in hm.iter() {
+//         let k : &usize = k;
+//         let k2 : usize = k.clone();
+//         v.push(3 as usize)
+//     }    
+// }
+
 #[test]
 pub fn test_join () {
     fn at_leaf(v:&Vec<usize>) -> Trie<usize,()> {

--- a/src/trie2.rs
+++ b/src/trie2.rs
@@ -8,7 +8,7 @@
 use std::fmt;
 use std::fmt::Debug;
 use std::hash::{Hash,Hasher};
-use std::collections::HashMap;
+//use std::collections::HashMap;
 use std::collections::hash_map::DefaultHasher;
 use adapton::engine::*;
 use adapton::macros::*;
@@ -42,8 +42,8 @@ impl fmt::Debug for Bits {
 
 #[derive(PartialEq,Eq,Clone,Debug,Hash)]
 pub struct Trie
-    <K:'static+Hash+Eq+Clone+Debug,
-     V:'static+Hash+Eq+Clone+Debug>
+    <K:'static+Hash+PartialEq+Eq+Clone+Debug,
+     V:'static+Hash+PartialEq+Eq+Clone+Debug>
 {
     meta:TrieMeta,
     rec:TrieRec<K,V>,
@@ -55,29 +55,29 @@ pub struct TrieMeta {
 }
 
 #[derive(PartialEq,Eq,Clone,Debug, Hash)]
-enum TrieRec<K:'static+Hash+Eq+Clone+Debug,
-             V:'static+Hash+Eq+Clone+Debug>
+enum TrieRec<K:'static+Hash+PartialEq+Eq+Clone+Debug,
+             V:'static+Hash+PartialEq+Eq+Clone+Debug>
 {
     Empty,
     Leaf(TrieLeaf<K,V>),
     Bin(TrieBin<K,V>),
 }
 #[derive(PartialEq,Eq,Clone,Debug)]
-struct TrieLeaf<K:'static+Hash+Eq+Clone+Debug,
-                V:'static+Hash+Eq+Clone+Debug> {
-    map:HashMap<K,(HashVal,V)>,
+struct TrieLeaf<K:'static+Hash+PartialEq+Eq+Clone+Debug,
+                V:'static+Hash+PartialEq+Eq+Clone+Debug> {
+    kvs:Vec<(K,HashVal,V)>,
 }
 #[derive(Hash,PartialEq,Eq,Clone,Debug)]
-struct TrieBin<K:'static+Hash+Eq+Clone+Debug,
-               V:'static+Hash+Eq+Clone+Debug> {
+struct TrieBin<K:'static+Hash+PartialEq+Eq+Clone+Debug,
+               V:'static+Hash+PartialEq+Eq+Clone+Debug> {
     bits:   Bits,
     name:   Name,
     left:   Art<TrieRec<K,V>>,
     right:  Art<TrieRec<K,V>>,
 }
 
-impl<K:'static+Hash+Eq+Clone+Debug,
-     V:'static+Hash+Eq+Clone+Debug>
+impl<K:'static+Hash+PartialEq+Eq+Clone+Debug,
+     V:'static+Hash+PartialEq+Eq+Clone+Debug>
     Hash for TrieLeaf<K,V> 
 {
     fn hash<H:Hasher>(&self, _h:&mut H) {
@@ -85,50 +85,55 @@ impl<K:'static+Hash+Eq+Clone+Debug,
     }
 }
 
-impl<K:'static+Hash+Eq+Clone+Debug,
-     V:'static+Hash+Eq+Clone+Debug> Trie<K,V> {
+impl<K:'static+Hash+PartialEq+Eq+Clone+Debug,
+     V:'static+Hash+PartialEq+Eq+Clone+Debug> Trie<K,V> {
 
     pub fn find (&self, k:&K) -> Option<V> {
         Self::find_hash(self, my_hash(k), k)
     }
 
     pub fn find_hash (t: &Trie<K,V>, h:HashVal, k:&K) -> Option<V> {
-        Self::find_rec(t, &t.rec, h, k)
+        Self::find_rec(t, &t.rec, h.clone(), h, k)
     }
 
-    fn find_rec (t: &Trie<K,V>, r:&TrieRec<K,V>, h:HashVal, k:&K) -> Option<V> {
+    fn find_rec (t: &Trie<K,V>, r:&TrieRec<K,V>, h:HashVal, h_rest:HashVal, k:&K) -> Option<V> {
         match r {
             &TrieRec::Empty => None,
-            &TrieRec::Leaf(ref l) => match l.map.get(k) { 
-                None => None,
-                Some(&(_,ref v)) => Some(v.clone()),
+            &TrieRec::Leaf(ref l) => {
+                let mut ans = None;
+                for &(ref k2,ref k2_hash,ref v) in l.kvs.iter() {
+                    if k2_hash == &h && k2 == k {
+                        ans = Some(v.clone())
+                    }
+                }
+                return ans
             },
             &TrieRec::Bin(ref b) => {
-                if h.0 & 1 == 0 {
-                    Self::find_rec(t, &get!(b.left), HashVal(h.0 >> 1), k)
+                if h_rest.0 & 1 == 0 {
+                    Self::find_rec(t, &get!(b.left), h, HashVal(h_rest.0 >> 1), k)
                 } else { 
-                    Self::find_rec(t, &get!(b.right), HashVal(h.0 >> 1), k)
+                    Self::find_rec(t, &get!(b.right), h, HashVal(h_rest.0 >> 1), k)
                 }
             }
         }
     }
 
-    fn split_map (map: HashMap<K,(HashVal,V)>, 
+    fn split_vec (vec: Vec<(K,HashVal,V)>,
                   bits_len:u32,
-                  mut map0:HashMap<K,(HashVal,V)>, 
-                  mut map1:HashMap<K,(HashVal,V)>)
-                  -> (HashMap<K,(HashVal,V)>, HashMap<K,(HashVal,V)>) 
+                  mut vec0:Vec<(K,HashVal,V)>, 
+                  mut vec1:Vec<(K,HashVal,V)>)
+                  -> (Vec<(K,HashVal,V)>, Vec<(K,HashVal,V)>)
     {
         //let mask : u64 = make_mask(bits_len as usize) as u64;
-        for (k,(k_hash,v)) in map.into_iter() {
+        for (k,k_hash,v) in vec.into_iter() {
             //assert_eq!((mask & k_hash) >> 1, bits.bits as u64); // XXX/???
             if 0 == (k_hash.0 & (1 << bits_len)) {
-                map0.insert(k, (k_hash,v));
+                vec0.push((k,k_hash,v));
             } else {
-                map1.insert(k, (k_hash,v));
+                vec1.push((k,k_hash,v));
             }
         };
-        (map0, map1)
+        (vec0, vec1)
     }
 
     fn meta (gauge:usize) -> TrieMeta {
@@ -139,29 +144,24 @@ impl<K:'static+Hash+Eq+Clone+Debug,
         Trie{meta:Self::meta(gauge), rec:TrieRec::Empty}
     }
 
-    pub fn from_vec(vec:&Vec<(K,V)>) -> Self { 
-        let mut hm = HashMap::new();
-        for &(ref k, ref v) in vec.iter() {
+    pub fn from_vec(vec_in:&Vec<(K,V)>) -> Self { 
+        let mut vec = Vec::new();
+        for &(ref k, ref v) in vec_in.iter() {
             let k_hash = my_hash(k);
-            hm.insert(k.clone(),(k_hash,v.clone()));
+            vec.push((k.clone(),k_hash,v.clone()));
         };
-        Trie{meta:Self::meta(hm.len()), 
-             rec:TrieRec::Leaf(TrieLeaf{map:hm})}
+        Trie{meta:Self::meta(vec.len()), 
+             rec:TrieRec::Leaf(TrieLeaf{kvs:vec})}
     }
 
-    pub fn from_key_vec(vec:&Vec<K>) -> Trie<K,()> { 
-        let mut hm = HashMap::new();
-        for k in vec.iter() {
+    pub fn from_key_vec(vec_in:&Vec<K>) -> Trie<K,()> { 
+        let mut vec = Vec::new();
+        for k in vec_in.iter() {
             let k_hash = my_hash(k);
-            hm.insert(k.clone(),(k_hash,()));
+            vec.push((k.clone(),k_hash,()));
         };
-        Trie{meta:Self::meta(hm.len()), 
-             rec:TrieRec::Leaf(TrieLeaf{map:hm})}
-    }
-
-    pub fn from_hashmap(hm:HashMap<K,(HashVal,V)>) -> Self { 
-        Trie{meta:Self::meta(hm.len()), 
-             rec:TrieRec::Leaf(TrieLeaf{map:hm})}
+        Trie{meta:Self::meta(vec.len()), 
+             rec:TrieRec::Leaf(TrieLeaf{kvs:vec})}
     }
 
     pub fn join (lt: Self, rt: Self, n:Name) -> Self {
@@ -176,50 +176,52 @@ impl<K:'static+Hash+Eq+Clone+Debug,
         (lbits, rbits)
     }
 
+    // TODO-Soon: Opt: After splitting a vec, create leaves by first checking whether the vec is empty.
+
     fn join_rec (meta:TrieMeta, lt: TrieRec<K,V>, rt: TrieRec<K,V>, bits:Bits, n:Name) -> TrieRec<K,V> {
         match (lt, rt) {
             (TrieRec::Empty, rt) => rt,
             (lt, TrieRec::Empty) => lt,
             (TrieRec::Leaf(mut l), TrieRec::Leaf(r)) => {
-                if l.map.len() == 0 { 
+                if l.kvs.len() == 0 { 
                     TrieRec::Leaf(r)
-                } else if r.map.len() == 0 {
+                } else if r.kvs.len() == 0 {
                     TrieRec::Leaf(l)
-                } else if l.map.len() + r.map.len() < meta.gauge {
+                } else if l.kvs.len() + r.kvs.len() < meta.gauge {
                     // Sub-Case: the leaves, when combined, are smaller than the gauge.
-                    for (k,(k_hash,v)) in r.map.into_iter() { 
-                        l.map.insert(k,(k_hash,v));
+                    for (k,k_hash,v) in r.kvs.into_iter() { 
+                        l.kvs.push((k,k_hash,v));
                     }
                     TrieRec::Leaf(l)
                 } else {
                     // Sub-Case: the leaves are large enough to justify not being combined.
-                    let (e0, e1) = (HashMap::new(), HashMap::new());
-                    let (l0, l1) = Self::split_map(l.map, bits.len, e0, e1);
-                    let (r0, r1) = Self::split_map(r.map, bits.len, l0, l1);
+                    let (e0, e1) = (Vec::new(), Vec::new());
+                    let (l0, l1) = Self::split_vec(l.kvs, bits.len, e0, e1);
+                    let (r0, r1) = Self::split_vec(r.kvs, bits.len, l0, l1);
                     let (n1, n2) = name_fork(n.clone());
-                    let t0 = cell(n1, TrieRec::Leaf(TrieLeaf{map:r0}));
-                    let t1 = cell(n2, TrieRec::Leaf(TrieLeaf{map:r1}));
+                    let t0 = cell(n1, TrieRec::Leaf(TrieLeaf{kvs:r0}));
+                    let t1 = cell(n2, TrieRec::Leaf(TrieLeaf{kvs:r1}));
                     TrieRec::Bin(TrieBin{left:t0, right:t1, bits:bits, name:n})
                 }
             },
             (TrieRec::Leaf(l), TrieRec::Bin(r)) => {
-                let (e0, e1) = (HashMap::new(), HashMap::new());
-                let (l0, l1) = Self::split_map(l.map, bits.len, e0, e1);
+                let (e0, e1) = (Vec::new(), Vec::new());
+                let (l0, l1) = Self::split_vec(l.kvs, bits.len, e0, e1);
                 let (b0, b1) = Self::split_bits(&bits);
                 let (n0, n1) = name_fork(n.clone());
                 let (m0, m1) = name_fork(r.name.clone());
-                let o0 = eager!(n0 =>> Self::join_rec, m:meta.clone(), l:TrieRec::Leaf(TrieLeaf{map:l0}), r:get!(r.left),  b:b0, n:m0);
-                let o1 = eager!(n1 =>> Self::join_rec, m:meta.clone(), l:TrieRec::Leaf(TrieLeaf{map:l1}), r:get!(r.right), b:b1, n:m1);
+                let o0 = eager!(n0 =>> Self::join_rec, m:meta.clone(), l:TrieRec::Leaf(TrieLeaf{kvs:l0}), r:get!(r.left),  b:b0, n:m0);
+                let o1 = eager!(n1 =>> Self::join_rec, m:meta.clone(), l:TrieRec::Leaf(TrieLeaf{kvs:l1}), r:get!(r.right), b:b1, n:m1);
                 TrieRec::Bin(TrieBin{ left:o0.0, right:o1.0, name:n, bits:bits })
             },
             (TrieRec::Bin(l), TrieRec::Leaf(r)) => {
-                let (e0, e1) = (HashMap::new(), HashMap::new());
-                let (r0, r1) = Self::split_map(r.map, bits.len, e0, e1);
+                let (e0, e1) = (Vec::new(), Vec::new());
+                let (r0, r1) = Self::split_vec(r.kvs, bits.len, e0, e1);
                 let (b0, b1) = Self::split_bits(&bits);
                 let (n0, n1) = name_fork(n.clone());
                 let (m0, m1) = name_fork(l.name.clone());
-                let o0 = eager!(n0 =>> Self::join_rec, m:meta.clone(), l:get!(l.left),  r:TrieRec::Leaf(TrieLeaf{map:r0}), b:b0, n:m0);
-                let o1 = eager!(n1 =>> Self::join_rec, m:meta.clone(), l:get!(l.right), r:TrieRec::Leaf(TrieLeaf{map:r1}), b:b1, n:m1);
+                let o0 = eager!(n0 =>> Self::join_rec, m:meta.clone(), l:get!(l.left),  r:TrieRec::Leaf(TrieLeaf{kvs:r0}), b:b0, n:m0);
+                let o1 = eager!(n1 =>> Self::join_rec, m:meta.clone(), l:get!(l.right), r:TrieRec::Leaf(TrieLeaf{kvs:r1}), b:b1, n:m1);
                 TrieRec::Bin(TrieBin{ left:o0.0, right:o1.0, name:n, bits:bits })
             },
             (TrieRec::Bin(l), TrieRec::Bin(r)) => {
@@ -239,12 +241,7 @@ impl<K:'static+Hash+Eq+Clone+Debug,
 #[test]
 pub fn test_join () {
     fn at_leaf(v:&Vec<usize>) -> Trie<usize,()> {
-        let mut hm = HashMap::new();
-        for x in v { 
-            let x_hash = my_hash(&x);
-            hm.insert(*x,(x_hash,()));
-        }
-        Trie::from_hashmap(hm)
+        Trie::<usize,()>::from_key_vec(v)
     }    
     fn at_bin(l:Trie<usize,()>,_lev:u32,n:Option<Name>,r:Trie<usize,()>) -> Trie<usize,()> {
         Trie::join(l,r,n.unwrap())
@@ -261,7 +258,7 @@ pub fn test_join () {
     let mut rng = thread_rng();
     let mut elms : AStack<usize,_> = AStack::new();
     let mut elmv : Vec<usize> = vec![];
-    for i in 0..1000 {
+    for i in 0..8 {
         let elm = rng.gen::<usize>() % 100;
         elmv.push(elm);
         elms.push(elm);
@@ -270,13 +267,13 @@ pub fn test_join () {
         }
     }
     let tree: RazTree<_,Count> = RazTree::memo_from(&AtHead(elms));
-    //println!("{:?}\n", tree);
+    println!("{:?}\n", tree);
 
     let trie = tree.fold_up_gauged(Rc::new(at_leaf),Rc::new(at_bin)).unwrap();
-    //println!("{:?}\n", trie);
+    println!("{:?}\n", trie);
 
     for i in elmv {
-        //println!("find {:?}", i);
+        println!("find {:?}", i);
         assert_eq!(trie.find(&i), Some(()));
     }
 }

--- a/src/trie2.rs
+++ b/src/trie2.rs
@@ -17,7 +17,7 @@ pub mod hammer_level_tree {
     use std::fmt::Debug;
     use std::hash::{Hash};
     use adapton::macros::*;
-    use adapton::engine::{Name,Art,cell,force};
+    use adapton::engine::{Name,Art,cell,force,thunk,ArtIdChoice};
     use raz::RazTree;
     use raz_meta::Count;
 
@@ -59,13 +59,13 @@ pub mod hammer_level_tree {
             LevTree{rec:Rec::Bin(BinCons{level:lev,recl:Box::new(l.rec),recr:Box::new(r.rec)})} 
         }
         pub fn name(lev:u32, n:Name, r:Self) -> Self {
-            LevTree{rec:Rec::Name(NameCons{level:lev,name:n.clone(), rec:Box::new(r.rec)}) }
+            LevTree{rec:Rec::Name(NameCons{level:lev,name:n, rec:Box::new(r.rec)}) }
         }
         fn art(a:Art<Rec<X>>) -> Self {
             LevTree{rec:Rec::Art(a)}
         }
-        pub fn fold_monoid<B:Clone>
-            (t:LevTree<X>, z:X, b:B, bin:fn(B,X,X)->X) -> X {
+        pub fn fold_monoid<B:'static+Clone+PartialEq+Eq+Debug+Hash>
+            (t:LevTree<X>, z:X, b:B, bin:fn(B,X,X)->X, art:fn(Art<X>,X)->X) -> X {
                 fn m_leaf<B:Clone,X>(m:(B,fn(B,X,X)->X,X), elms:Vec<X>) -> X { 
                     let mut x = m.2;
                     for elm in elms { x=m.1(m.0.clone(), x, elm) };
@@ -78,10 +78,15 @@ pub mod hammer_level_tree {
                                         (B,fn(B,X,X)->X,X),X>
                     (t,
                      (b.clone(),bin,z.clone()), m_leaf,
-                     (b,bin,z), m_bin)
+                     (b,bin,z), m_bin, 
+                     art)
             }
 
-        pub fn fold_up<L:Clone,B:Clone,N:Clone,R>
+        pub fn fold_up
+            <L:'static+Clone+PartialEq+Eq+Debug+Hash,
+             B:'static+Clone+PartialEq+Eq+Debug+Hash,
+             N:'static+Clone+PartialEq+Eq+Debug+Hash,
+             R:'static+Clone+PartialEq+Eq+Debug+Hash>
             (t:LevTree<X>, 
              l:L, leaf:fn(L,Vec<X>)->R, 
              b:B, bin:fn(B,u32,R,R)->R,
@@ -89,7 +94,10 @@ pub mod hammer_level_tree {
                 Self::fold_up_rec(t.rec, l, leaf, b, bin, n, name)
             }
         
-        fn fold_up_rec<L:Clone,B:Clone,N:Clone,R>
+        fn fold_up_rec<L:'static+Clone+PartialEq+Eq+Debug+Hash,
+                       B:'static+Clone+PartialEq+Eq+Debug+Hash,
+                       N:'static+Clone+PartialEq+Eq+Debug+Hash,
+                       R:'static+Clone+PartialEq+Eq+Debug+Hash>
             (t:Rec<X>, 
              l:L, leaf:fn(L,Vec<X>)->R, 
              b:B, bin:fn(B,u32,R,R)->R,
@@ -109,31 +117,46 @@ pub mod hammer_level_tree {
                 }
             }
 
-        pub fn fold_up_namebin<L:Clone,B:Clone,R>
+        pub fn fold_up_namebin
+            <L:'static+Clone+PartialEq+Eq+Debug+Hash,
+             B:'static+Clone+PartialEq+Eq+Debug+Hash,
+             R:'static+Clone+PartialEq+Eq+Debug+Hash>
             (t:LevTree<X>, 
              l:L, leaf:fn(L,Vec<X>)->R, 
-             b:B, namebin:fn(B,u32,Option<Name>,R,R)->R) -> R {
-                Self::fold_up_namebin_rec(t.rec, l, leaf, b, None, namebin)
+             b:B, namebin:fn(B,u32,Option<Name>,R,R)->R, 
+             art:fn(Art<R>,R)->R) -> R {
+                Self::fold_up_namebin_rec(t.rec, l, leaf, b, None, namebin, art)
             }
         
-        fn fold_up_namebin_rec<L:Clone,B:Clone,R>
-            (t:Rec<X>, 
+        fn fold_up_namebin_rec
+            <L:'static+Clone+PartialEq+Eq+Debug+Hash,
+             B:'static+Clone+PartialEq+Eq+Debug+Hash,
+             R:'static+Clone+PartialEq+Eq+Debug+Hash>             
+            (t:Rec<X>,
              l:L, leaf:fn(L,Vec<X>)->R,
-             b:B, n:Option<Name>, namebin:fn(B,u32,Option<Name>,R,R)->R) -> R {
-                 match t {
-                    Rec::Art(a) => Self::fold_up_namebin_rec(get!(a), l, leaf, b, n, namebin),
-                     Rec::Leaf(leafcons) => leaf(l, leafcons.elms),
-                     Rec::Bin(bincons)   => {
-                         let r1 = Self::fold_up_namebin_rec(*bincons.recl, l.clone(), leaf, b.clone(), None, namebin);
-                         let r2 = Self::fold_up_namebin_rec(*bincons.recr, l.clone(), leaf, b.clone(), None, namebin);
-                         namebin(b, bincons.level, n, r1, r2)
-                     }
-                    Rec::Name(namecons) => {
-                        Self::fold_up_namebin_rec(*namecons.rec, l, leaf, b, Some(namecons.name.clone()), namebin)
+             b:B, n:Option<Name>,
+             namebin:fn(B,u32,Option<Name>,R,R)->R,
+             art:fn(Art<R>,R)->R) -> R {
+                match t {
+                    Rec::Art(a) => Self::fold_up_namebin_rec(get!(a), l, leaf, b, n, namebin, art),
+                    Rec::Leaf(leafcons) => leaf(l, leafcons.elms),
+                    Rec::Bin(bincons)   => {
+                        let r1 = Self::fold_up_namebin_rec(*bincons.recl, l.clone(), leaf, b.clone(), None, namebin, art);
+                        let r2 = Self::fold_up_namebin_rec(*bincons.recr, l.clone(), leaf, b.clone(), None, namebin, art);
+                        namebin(b, bincons.level, n, r1, r2)
                     }
-                 }
+                    Rec::Name(namecons) => {
+                        let (a,x) = eager!( 
+                            namecons.name.clone() =>> Self::fold_up_namebin_rec,
+                            t:*namecons.rec, 
+                            l:l, leaf:leaf,
+                            b:b, n:Some(namecons.name), namebin:namebin, art:art 
+                        );
+                        art(a,x)
+                    }
+                }
             }
-
+        
         pub fn from_raz_tree(t:RazTree<X,Count>) -> LevTree<X> {
             fn at_leaf<X:'static+Clone+PartialEq+Eq+Debug+Hash>
                 (v:&Vec<X>) -> LevTree<X> {
@@ -197,25 +220,32 @@ pub struct TrieMeta {
 }
 
 #[derive(PartialEq,Eq,Clone,Debug,Hash)]
-enum TrieRec<K:'static+Hash+PartialEq+Eq+Clone+Debug,
+pub enum TrieRec<K:'static+Hash+PartialEq+Eq+Clone+Debug,
              V:'static+Hash+PartialEq+Eq+Clone+Debug>
 {
     Empty,
     Leaf(TrieLeaf<K,V>),
     Bin(TrieBin<K,V>),
+    Name(TrieName<K,V>),
+    Art(Art<TrieRec<K,V>>),
 }
 #[derive(PartialEq,Eq,Clone,Debug,Hash)]
-struct TrieLeaf<K:'static+Hash+PartialEq+Eq+Clone+Debug,
-                V:'static+Hash+PartialEq+Eq+Clone+Debug> {
+pub struct TrieLeaf<K:'static+Hash+PartialEq+Eq+Clone+Debug,
+                    V:'static+Hash+PartialEq+Eq+Clone+Debug> {
     kvs:Rc<Vec<(K,HashVal,V)>>,
 }
 #[derive(Hash,PartialEq,Eq,Clone,Debug)]
-struct TrieBin<K:'static+Hash+PartialEq+Eq+Clone+Debug,
-               V:'static+Hash+PartialEq+Eq+Clone+Debug> {
+pub struct TrieBin<K:'static+Hash+PartialEq+Eq+Clone+Debug,
+                   V:'static+Hash+PartialEq+Eq+Clone+Debug> {
     bits:   Bits,
+    left:   Box<TrieRec<K,V>>,
+    right:  Box<TrieRec<K,V>>,
+}
+#[derive(Hash,PartialEq,Eq,Clone,Debug)]
+pub struct TrieName<K:'static+Hash+PartialEq+Eq+Clone+Debug,
+                    V:'static+Hash+PartialEq+Eq+Clone+Debug> {
     name:   Name,
-    left:   Art<TrieRec<K,V>>,
-    right:  Art<TrieRec<K,V>>,
+    rec:    Box<TrieRec<K,V>>,
 }
 
 impl<K:'static+Hash+PartialEq+Eq+Clone+Debug,
@@ -231,6 +261,8 @@ impl<K:'static+Hash+PartialEq+Eq+Clone+Debug,
 
     fn find_rec (t: &Trie<K,V>, r:&TrieRec<K,V>, h:HashVal, h_rest:HashVal, k:&K) -> Option<V> {
         match r {
+            &TrieRec::Art(ref a) => Self::find_rec(t, &get!(a), h, h_rest, k),
+            &TrieRec::Name(ref n) => Self::find_rec(t, &*n.rec, h, h_rest, k),
             &TrieRec::Empty => None,
             &TrieRec::Leaf(ref l) => {
                 let mut ans = None;
@@ -243,9 +275,9 @@ impl<K:'static+Hash+PartialEq+Eq+Clone+Debug,
             },
             &TrieRec::Bin(ref b) => {
                 if h_rest.0 & 1 == 0 {
-                    Self::find_rec(t, &get!(b.left), h, HashVal(h_rest.0 >> 1), k)
+                    Self::find_rec(t, &*b.left, h, HashVal(h_rest.0 >> 1), k)
                 } else { 
-                    Self::find_rec(t, &get!(b.right), h, HashVal(h_rest.0 >> 1), k)
+                    Self::find_rec(t, &*b.right, h, HashVal(h_rest.0 >> 1), k)
                 }
             }
         }
@@ -307,10 +339,10 @@ impl<K:'static+Hash+PartialEq+Eq+Clone+Debug,
              rec:TrieRec::Leaf(TrieLeaf{kvs:Rc::new(vec)})}
     }
 
-    pub fn join (lt: Self, rt: Self, n:Name) -> Self {
+    pub fn join (n:Option<Name>, lt: Self, rt: Self) -> Self {
         //assert_eq!(lt.gauge, rt.gauge); // ??? -- Or take the min? Or the max? Or the average?
         let gauge = if lt.meta.gauge > rt.meta.gauge { lt.meta.gauge } else { rt.meta.gauge };
-        Trie{rec:Self::join_rec(TrieMeta{gauge:gauge}, lt.rec, rt.rec, Bits{len:0, bits:0}, n),..lt}
+        Trie{rec:Self::join_rec(TrieMeta{gauge:gauge}, n, lt.rec, rt.rec, Bits{len:0, bits:0}),..lt}
     }
 
     fn split_bits (bits:&Bits) -> (Bits, Bits) {
@@ -328,6 +360,8 @@ impl<K:'static+Hash+PartialEq+Eq+Clone+Debug,
 
     fn is_wf_rec (t:&TrieRec<K,V>, bits:Bits) -> bool {
         match *t {
+            TrieRec::Art(ref a) => Self::is_wf_rec(&get!(a), bits),
+            TrieRec::Name(ref n) => Self::is_wf_rec(&*n.rec, bits),
             TrieRec::Empty => true,
             TrieRec::Leaf(ref leaf) => {
                 // Check that all of the hash values match the given bit pattern of bits.
@@ -342,8 +376,8 @@ impl<K:'static+Hash+PartialEq+Eq+Clone+Debug,
             // Check bit patterns match, and that recursive trees are well-formed.
             TrieRec::Bin(ref b) => { 
                 let (b0, b1) = Self::split_bits(&bits);
-                let lwf = Self::is_wf_rec(& get!(b.left), b0);
-                let rwf = Self::is_wf_rec(& get!(b.right), b1);
+                let lwf = Self::is_wf_rec(&*b.left, b0);
+                let rwf = Self::is_wf_rec(&*b.right, b1);
                 b.bits == bits && lwf && rwf 
             }
         }
@@ -353,6 +387,90 @@ impl<K:'static+Hash+PartialEq+Eq+Clone+Debug,
         Self::is_wf_rec(&self.rec, Bits{bits:0, len:0})
     }
 
+    fn join_rec (meta:TrieMeta, n:Option<Name>, lt: TrieRec<K,V>, rt: TrieRec<K,V>, bits:Bits) -> TrieRec<K,V> {
+        match n {
+            Some(n) => {
+                let (a,_trie) = eager!(n.clone() =>> Self::join_rec, meta:meta, n:None, lt:lt, rt:rt, bits:bits);
+                TrieRec::Name(TrieName{name:n, rec:Box::new(TrieRec::Art(a))})
+            },
+            None => { match (lt, rt) {
+                (TrieRec::Empty,   TrieRec::Empty)   => TrieRec::Empty,
+                (TrieRec::Empty,   TrieRec::Leaf(r)) => TrieRec::Leaf(r),
+                (TrieRec::Leaf(l), TrieRec::Empty  ) => TrieRec::Leaf(l),
+
+                (TrieRec::Name(n), rt) => { Self::join_rec (meta, Some(n.name), *n.rec, rt, bits) },
+                (lt, TrieRec::Name(n)) => { Self::join_rec (meta, None,         lt, *n.rec, bits) },
+                
+                (TrieRec::Art(a), rt) => { Self::join_rec (meta, n, get!(a), rt, bits) },
+                (lt, TrieRec::Art(a)) => { Self::join_rec (meta, n, lt, get!(a), bits) },
+
+                (TrieRec::Leaf(l), TrieRec::Leaf(r)) => {
+                    if l.kvs.len() == 0 { 
+                        TrieRec::Leaf(r)
+                    } else if r.kvs.len() == 0 {
+                        TrieRec::Leaf(l)
+                    } else if l.kvs.len() + r.kvs.len() < meta.gauge {
+                        // Sub-Case: the leaves, when combined, are smaller than the gauge.
+                        let mut vec = (*l.kvs).clone();
+                        for &(ref k, ref k_hash, ref v) in r.kvs.iter() { 
+                            vec.push((k.clone(),k_hash.clone(),v.clone()));
+                        }
+                        Self::leaf_or_empty(vec)
+                    } else {
+                        // Sub-Case: the leaves are large enough to justify not being combined.
+                        let (e0, e1) = (Vec::new(), Vec::new());
+                        let (l0, l1) = Self::split_vec(l.kvs, bits.len, e0, e1);
+                        let (r0, r1) = Self::split_vec(r.kvs, bits.len, l0, l1);
+                        let t0 = Box::new(TrieRec::Leaf(TrieLeaf{kvs:Rc::new(r0)}));
+                        let t1 = Box::new(TrieRec::Leaf(TrieLeaf{kvs:Rc::new(r1)}));
+                        TrieRec::Bin(TrieBin{left:t0, right:t1, bits:bits})
+                    }
+                },
+                (TrieRec::Empty, TrieRec::Bin(r)) => {
+                    let (b0, b1) = Self::split_bits(&bits);
+                    let o0 = Self::join_rec(meta.clone(), None, TrieRec::Empty, *r.left, b0);
+                    let o1 = Self::join_rec(meta.clone(), None, TrieRec::Empty, *r.right, b1);
+                    TrieRec::Bin(TrieBin{ left:Box::new(o0), right:Box::new(o1), bits:bits })
+                },
+                (TrieRec::Leaf(l), TrieRec::Bin(r)) => {
+                    let (e0, e1) = (Vec::new(), Vec::new());
+                    let (l0, l1) = Self::split_vec(l.kvs, bits.len, e0, e1);
+                    let (b0, b1) = Self::split_bits(&bits);
+                    let o0 = Self::join_rec(meta.clone(), None, Self::leaf_or_empty(l0), *r.left, b0);
+                    let o1 = Self::join_rec(meta.clone(), None, Self::leaf_or_empty(l1), *r.right, b1);
+                    TrieRec::Bin(TrieBin{ left:Box::new(o0), right:Box::new(o1), bits:bits })
+                },
+                (TrieRec::Bin(l), TrieRec::Empty) => {
+                    let (b0, b1) = Self::split_bits(&bits);
+                    let o0 = Self::join_rec(meta.clone(), None, *l.left, TrieRec::Empty, b0);
+                    let o1 = Self::join_rec(meta.clone(), None, *l.right, TrieRec::Empty, b1);
+                    TrieRec::Bin(TrieBin{ left:Box::new(o0), right:Box::new(o1), bits:bits })
+                },
+                (TrieRec::Bin(l), TrieRec::Leaf(r)) => {
+                    let (e0, e1) = (Vec::new(), Vec::new());
+                    let (r0, r1) = Self::split_vec(r.kvs, bits.len, e0, e1);
+                    let (b0, b1) = Self::split_bits(&bits);
+                    let o0 = Self::join_rec(meta.clone(), None, *l.left, Self::leaf_or_empty(r0), b0);
+                    let o1 = Self::join_rec(meta.clone(), None, *l.right, Self::leaf_or_empty(r1), b1);
+                    TrieRec::Bin(TrieBin{ left:Box::new(o0), right:Box::new(o1), bits:bits })
+                },
+                (TrieRec::Bin(l), TrieRec::Bin(r)) => {
+                    let test1 = l.bits == bits;
+                    let test2 = l.bits == r.bits;
+                    if !(test1 && test2) {
+                        panic!("\nInternal error: {:?} {:?} -- bits:{:?} l.bits:{:?} r.bits:{:?}!!!\n", 
+                               test1, test2, bits, l.bits, r.bits);
+                    };
+                    let (b0, b1) = Self::split_bits(&bits);
+                    let o0 = Self::join_rec(meta.clone(), None, *l.left,  *r.left, b0);
+                    let o1 = Self::join_rec(meta.clone(), None, *l.right, *r.right, b1);
+                    TrieRec::Bin(TrieBin{ left:Box::new(o0), right:Box::new(o1), bits:bits })
+                }
+            }}
+        }   
+    }
+
+/*
     fn join_rec (meta:TrieMeta, lt: TrieRec<K,V>, rt: TrieRec<K,V>, bits:Bits, n:Name) -> TrieRec<K,V> {
         match (lt, rt) {
             (TrieRec::Empty,   TrieRec::Empty)   => TrieRec::Empty,
@@ -432,7 +550,8 @@ impl<K:'static+Hash+PartialEq+Eq+Clone+Debug,
                 TrieRec::Bin(TrieBin{ left:o0.0, right:o1.0, name:n, bits:bits })
             }
         }
-    }               
+    }
+     */
 }
 
 #[test] pub fn test_join_10_1   () { test_join(10,1) }
@@ -497,12 +616,15 @@ pub fn test_join (size:usize, gauge:usize) {
     fn at_namebin(_:(), _lev:u32,n:Option<Name>,l:Trie<usize,()>,r:Trie<usize,()>) -> Trie<usize,()> {
         assert!(l.is_wf());
         assert!(r.is_wf());
-        ns(n.clone().unwrap(), || Trie::join(l,r,n.unwrap()) )
+        ns(n.clone().unwrap(), || Trie::join(n,l,r) )
+    }
+    fn at_art(_a:Art<Trie<usize,()>>, t:Trie<usize,()>) -> Trie<usize,()> {
+        t 
     }
     let trie = ns( name_of_str("trie_of_lev_tree"),
                    || LevTree::fold_up_namebin( lev_tree,
                                                 (), at_leaf,
-                                                (), at_namebin ) );
+                                                (), at_namebin, at_art ) );
     println!("{:?}\n", trie);
 
     for i in elmv {

--- a/src/trie2.rs
+++ b/src/trie2.rs
@@ -237,21 +237,6 @@ impl<K:'static+Hash+PartialEq+Eq+Clone+Debug,
     }               
 }
 
-
-// #[test]
-// fn test_clone() {
-//     use std::collections::hash_map::HashMap;
-//     let mut hm : HashMap<usize, usize> = HashMap::new();
-//     hm.insert(1, 2);
-//     hm.insert(3, 4);
-//     let mut v : Vec<usize> = vec![];
-//     for (k,v) in hm.iter() {
-//         let k : &usize = k;
-//         let k2 : usize = k.clone();
-//         v.push(3 as usize)
-//     }    
-// }
-
 #[test]
 pub fn test_join () {
     fn at_leaf(v:&Vec<usize>) -> Trie<usize,()> {

--- a/src/trie2.rs
+++ b/src/trie2.rs
@@ -405,8 +405,6 @@ impl<K:'static+Hash+PartialEq+Eq+Clone+Debug,
                 }
             },
             (TrieRec::Empty, TrieRec::Bin(r)) => {
-                //let (e0, e1) = (Vec::new(), Vec::new());
-                //let (l0, l1) = Self::split_vec(l.kvs, bits.len, e0, e1);
                 let (b0, b1) = Self::split_bits(&bits);
                 let (n0, n1) = name_fork(n.clone());
                 let (m0, m1) = name_fork(r.name.clone());


### PR DESCRIPTION
This PR implements the first of the two finite map representations described in https://github.com/cuplv/iodyn.rust/issues/20.

r @kyleheadley 
(following the Rust github conventions for requesting a review from @kyleheadley)

modules `trie1` and `trie2` are two variants of hash tries, for representing finite maps computed from sequences.  The second variant is a bit simpler, with comparable performance to the first.  In a later PR, I'll probably remove the first one and rename.

Performance
---------------

The image below shows that at 100k random `usize`s, constructing a Rust hashmap requires ~400ms to build (on my mac book air).  Meanwhile, it only takes 10ms to change propagate the trie construction algorithm after we edit the initial sequence.

![image](https://user-images.githubusercontent.com/1183963/29027545-5b708dcc-7b3e-11e7-8ef8-4e97cba94433.png)

To reproduce this, go into branch `dev-hammer`, under `eval` and do `cargo run --example unique_elms`.  I suspect that a more powerful computer may have similar, but slightly better results overall.

Commit history
------------------

I accidentally included a few commits (from `master`) of @kyleheadley below.  There's probably a way of correcting this, but it's easier just to recommit this time.  I know what I did, and how to avoid it next time (always do `git pull --rebase origin/master` before doing a PR, and don't pull without rebasing).

*Update*: I think I fixed this by rebasing the PR to target `dev`, not `master.